### PR TITLE
Add custom hotkey support for dictation with 2-3 keypress validation

### DIFF
--- a/Sources/LookMaNoHands/Models/Hotkey.swift
+++ b/Sources/LookMaNoHands/Models/Hotkey.swift
@@ -1,0 +1,151 @@
+import Foundation
+import CoreGraphics
+
+/// Represents a keyboard shortcut (key + modifiers)
+struct Hotkey: Codable, Equatable, Hashable {
+    /// The virtual key code (CGKeyCode)
+    let keyCode: UInt16
+
+    /// Modifier flags (Cmd, Shift, Option, Control)
+    let modifiers: ModifierFlags
+
+    /// Modifier flags as a Codable struct
+    struct ModifierFlags: Codable, Equatable, Hashable {
+        var command: Bool = false
+        var shift: Bool = false
+        var option: Bool = false
+        var control: Bool = false
+
+        /// Convert to CGEventFlags for event matching
+        var cgEventFlags: CGEventFlags {
+            var flags: CGEventFlags = []
+            if command { flags.insert(.maskCommand) }
+            if shift { flags.insert(.maskShift) }
+            if option { flags.insert(.maskAlternate) }
+            if control { flags.insert(.maskControl) }
+            return flags
+        }
+
+        /// Initialize from CGEventFlags
+        init(from cgFlags: CGEventFlags) {
+            command = cgFlags.contains(.maskCommand)
+            shift = cgFlags.contains(.maskShift)
+            option = cgFlags.contains(.maskAlternate)
+            control = cgFlags.contains(.maskControl)
+        }
+
+        init(command: Bool = false, shift: Bool = false,
+             option: Bool = false, control: Bool = false) {
+            self.command = command
+            self.shift = shift
+            self.option = option
+            self.control = control
+        }
+
+        /// Check if any modifiers are set
+        var hasModifiers: Bool {
+            command || shift || option || control
+        }
+
+        /// Display string for modifiers (e.g., "⌘⇧")
+        var displayString: String {
+            var parts: [String] = []
+            if control { parts.append("⌃") }
+            if option { parts.append("⌥") }
+            if shift { parts.append("⇧") }
+            if command { parts.append("⌘") }
+            return parts.joined()
+        }
+    }
+
+    /// Human-readable display string (e.g., "⌘⇧R")
+    var displayString: String {
+        let modifierStr = modifiers.displayString
+        let keyStr = Hotkey.keyCodeToString(keyCode)
+        if modifierStr.isEmpty {
+            return keyStr
+        }
+        return modifierStr + keyStr
+    }
+
+    /// Display string with full modifier names (e.g., "Cmd+Shift+R")
+    var verboseDisplayString: String {
+        var parts: [String] = []
+        if modifiers.control { parts.append("Ctrl") }
+        if modifiers.option { parts.append("Opt") }
+        if modifiers.shift { parts.append("Shift") }
+        if modifiers.command { parts.append("Cmd") }
+        parts.append(Hotkey.keyCodeToString(keyCode))
+        return parts.joined(separator: "+")
+    }
+
+    /// Check if this hotkey is a single modifier key (Caps Lock, Fn, etc.)
+    var isSingleModifierKey: Bool {
+        !modifiers.hasModifiers && Hotkey.isModifierKeyCode(keyCode)
+    }
+
+    /// Predefined hotkeys for common trigger keys
+    static let capsLock = Hotkey(keyCode: 57, modifiers: .init())
+    static let rightOption = Hotkey(keyCode: 61, modifiers: .init())
+    static let fn = Hotkey(keyCode: 63, modifiers: .init())
+
+    /// Check if this is one of the predefined single-key triggers
+    /// These are exempt from the 2-3 keypress validation rule
+    var isPredefinedTrigger: Bool {
+        self == .capsLock || self == .rightOption || self == .fn
+    }
+
+    // MARK: - Key Code Utilities
+
+    /// Map key codes to human-readable strings
+    static func keyCodeToString(_ keyCode: UInt16) -> String {
+        let keyMap: [UInt16: String] = [
+            // Letters
+            0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G", 6: "Z", 7: "X",
+            8: "C", 9: "V", 11: "B", 12: "Q", 13: "W", 14: "E", 15: "R",
+            16: "Y", 17: "T", 18: "1", 19: "2", 20: "3", 21: "4", 22: "6",
+            23: "5", 24: "=", 25: "9", 26: "7", 27: "-", 28: "8", 29: "0",
+            30: "]", 31: "O", 32: "U", 33: "[", 34: "I", 35: "P", 36: "↩",
+            37: "L", 38: "J", 39: "'", 40: "K", 41: ";", 42: "\\", 43: ",",
+            44: "/", 45: "N", 46: "M", 47: ".", 48: "⇥", 49: "Space",
+            50: "`", 51: "⌫", 53: "⎋",
+            // Modifier keys
+            54: "⌘R", 55: "⌘L", 56: "⇧L", 57: "⇪", 58: "⌥L", 59: "⌃L",
+            60: "⇧R", 61: "⌥R", 62: "⌃R", 63: "fn",
+            // Function keys
+            122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5", 97: "F6",
+            98: "F7", 100: "F8", 101: "F9", 109: "F10", 103: "F11", 111: "F12",
+            105: "F13", 107: "F14", 113: "F15", 106: "F16", 64: "F17", 79: "F18",
+            80: "F19", 90: "F20",
+            // Arrow keys
+            123: "←", 124: "→", 125: "↓", 126: "↑",
+            // Other
+            114: "Help", 115: "Home", 116: "⇞", 117: "⌦", 119: "End", 121: "⇟",
+            71: "Clear", 76: "⌅", 65: ".",
+            // Numpad
+            67: "*", 69: "+", 75: "/", 78: "-", 81: "=",
+            82: "0", 83: "1", 84: "2", 85: "3", 86: "4",
+            87: "5", 88: "6", 89: "7", 91: "8", 92: "9"
+        ]
+        return keyMap[keyCode] ?? "Key\(keyCode)"
+    }
+
+    /// Check if a key code is a modifier key
+    static func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+        // Caps Lock (57), Shift L/R (56, 60), Control L/R (59, 62),
+        // Option L/R (58, 61), Command L/R (55, 54), Fn (63)
+        [54, 55, 56, 57, 58, 59, 60, 61, 62, 63].contains(keyCode)
+    }
+
+    /// System-reserved hotkeys that should not be used
+    static let reservedHotkeys: Set<String> = [
+        "⌘Q", "⌘W", "⌘H", "⌘M", "⌘⇥", "⌘Space",
+        "⌃←", "⌃→", "⌃↑", "⌃↓",
+        "⌘⌥⎋" // Force quit
+    ]
+
+    /// Check if this hotkey is reserved by the system
+    var isReserved: Bool {
+        Hotkey.reservedHotkeys.contains(displayString)
+    }
+}

--- a/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
+++ b/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
@@ -2,31 +2,58 @@ import Foundation
 import CoreGraphics
 import AppKit
 
-/// Monitors keyboard events system-wide to detect the trigger key (Caps Lock by default)
+/// Monitors keyboard events system-wide to detect the configured trigger hotkey
 /// Requires Accessibility permissions to function
 class KeyboardMonitor {
-    
+
     // MARK: - Types
-    
+
     /// Callback type for when trigger key is pressed
     typealias TriggerCallback = () -> Void
-    
+
     // MARK: - Properties
-    
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var onTrigger: TriggerCallback?
-    
+
+    /// The hotkey configuration to listen for
+    private var hotkey: Hotkey = .capsLock
+
+    /// Lock for thread-safe hotkey access
+    private let hotkeyLock = NSLock()
+
     /// Whether the monitor is currently active
     private(set) var isMonitoring = false
-    
+
+    /// Track modifier key state to avoid double-triggering
+    private var lastModifierFlags: CGEventFlags = []
+
     // MARK: - Public Methods
-    
+
+    /// Update the hotkey configuration (can be called while monitoring)
+    func setHotkey(_ newHotkey: Hotkey) {
+        hotkeyLock.lock()
+        defer { hotkeyLock.unlock() }
+        hotkey = newHotkey
+        lastModifierFlags = [] // Reset state when hotkey changes
+        NSLog("⌨️ KeyboardMonitor: Hotkey updated to %@", newHotkey.displayString)
+    }
+
+    /// Get the current hotkey
+    func getHotkey() -> Hotkey {
+        hotkeyLock.lock()
+        defer { hotkeyLock.unlock() }
+        return hotkey
+    }
+
     /// Start monitoring for the trigger key
-    /// - Parameter callback: Called when the trigger key is pressed
+    /// - Parameters:
+    ///   - hotkey: The hotkey to monitor for (defaults to Caps Lock)
+    ///   - callback: Called when the trigger key is pressed
     /// - Returns: True if monitoring started successfully
     @discardableResult
-    func startMonitoring(onTrigger callback: @escaping TriggerCallback) -> Bool {
+    func startMonitoring(hotkey: Hotkey = .capsLock, onTrigger callback: @escaping TriggerCallback) -> Bool {
         guard !isMonitoring else { return true }
 
         // Check accessibility permission and prompt if needed
@@ -37,100 +64,156 @@ class KeyboardMonitor {
             print("KeyboardMonitor: Accessibility permission not granted - prompt shown")
             return false
         }
-        
+
+        self.hotkey = hotkey
         self.onTrigger = callback
-        
-        // Create event tap for keyboard events
-        // We're interested in kCGEventFlagsChanged which fires when modifier keys change
-        let eventMask = (1 << CGEventType.flagsChanged.rawValue)
-        
+
+        // Determine which events to monitor
+        // For single modifier keys (Caps Lock, etc.), monitor flagsChanged
+        // For key+modifier combinations, monitor keyDown
+        // Monitor both to support dynamic switching
+        var eventMask: CGEventMask = 0
+        eventMask |= (1 << CGEventType.flagsChanged.rawValue)
+        eventMask |= (1 << CGEventType.keyDown.rawValue)
+
         // The event tap callback
         let callback: CGEventTapCallBack = { proxy, type, event, refcon in
             guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
-            
+
             let monitor = Unmanaged<KeyboardMonitor>.fromOpaque(refcon).takeUnretainedValue()
             monitor.handleEvent(type: type, event: event)
-            
+
             return Unmanaged.passUnretained(event)
         }
-        
+
         // Create the event tap
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
-            eventsOfInterest: CGEventMask(eventMask),
+            eventsOfInterest: eventMask,
             callback: callback,
             userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else {
             print("KeyboardMonitor: Failed to create event tap")
             return false
         }
-        
+
         self.eventTap = tap
-        
+
         // Create run loop source and add to current run loop
         let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         self.runLoopSource = runLoopSource
-        
+
         CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
-        
+
         isMonitoring = true
-        NSLog("⌨️ KeyboardMonitor: Started monitoring successfully!")
+        NSLog("⌨️ KeyboardMonitor: Started monitoring for %@", hotkey.displayString)
 
         return true
     }
-    
+
     /// Stop monitoring for keyboard events
     func stopMonitoring() {
         guard isMonitoring else { return }
-        
+
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
-        
+
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
         }
-        
+
         eventTap = nil
         runLoopSource = nil
         onTrigger = nil
         isMonitoring = false
-        
+
         print("KeyboardMonitor: Stopped monitoring")
     }
-    
+
     // MARK: - Private Methods
-    
+
     private func handleEvent(type: CGEventType, event: CGEvent) {
-        // We're looking for Caps Lock
-        // Caps Lock is indicated by the NSEvent.ModifierFlags.capsLock flag
-        
-        guard type == .flagsChanged else { return }
+        let currentHotkey = getHotkey()
 
-        // Check if Caps Lock was just pressed
-        // Note: This is a simplified check. We may need more sophisticated
-        // logic to detect press vs release and avoid triggering on every toggle.
-        
-        // For Caps Lock, we detect the press by looking at the keycode
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        
-        // Caps Lock keycode is 57
-        if keyCode == 57 {
-            NSLog("🔔 KeyboardMonitor: Caps Lock detected (keycode: %d)", keyCode)
+        if currentHotkey.isSingleModifierKey {
+            // Handle single modifier keys (Caps Lock, Right Option, Fn, etc.)
+            guard type == .flagsChanged else { return }
 
-            // Call the trigger callback on the main thread
-            DispatchQueue.main.async { [weak self] in
-                NSLog("🔔 KeyboardMonitor: Triggering callback...")
-                self?.onTrigger?()
+            let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+            let eventFlags = event.flags
+
+            // Only trigger if this is the correct key
+            guard keyCode == Int64(currentHotkey.keyCode) else { return }
+
+            // Determine the relevant flag for this modifier key
+            let relevantFlag: CGEventFlags
+            switch currentHotkey.keyCode {
+            case 57: // Caps Lock
+                relevantFlag = .maskAlphaShift
+            case 61: // Right Option
+                relevantFlag = .maskAlternate
+            case 63: // Fn
+                relevantFlag = .maskSecondaryFn
+            default:
+                return
+            }
+
+            // Check if the modifier is being pressed (not released)
+            let isPressed = eventFlags.contains(relevantFlag)
+            let wasPressed = lastModifierFlags.contains(relevantFlag)
+
+            // Update state
+            lastModifierFlags = eventFlags
+
+            // Only trigger on press (not release)
+            if isPressed && !wasPressed {
+                NSLog("🔔 KeyboardMonitor: %@ detected (press)", currentHotkey.displayString)
+                DispatchQueue.main.async { [weak self] in
+                    self?.onTrigger?()
+                }
+            }
+        } else {
+            // Handle key+modifier combinations
+            // Only process keyDown events for key+modifier combinations
+            guard type == .keyDown else { return }
+
+            let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+            // Check if keycode matches
+            guard keyCode == Int64(currentHotkey.keyCode) else { return }
+
+            // Key matches! Now check modifiers
+            let eventFlags = event.flags
+
+            // Extract only the modifier flags we care about
+            let relevantMask: CGEventFlags = [.maskCommand, .maskShift, .maskAlternate, .maskControl]
+            let eventModifiers = eventFlags.intersection(relevantMask)
+            let expectedFlags = currentHotkey.modifiers.cgEventFlags
+
+            NSLog("🔍 Hotkey candidate: key=%@ (code=%d), eventMods=0x%lx, expectedMods=0x%lx",
+                  Hotkey.keyCodeToString(UInt16(keyCode)),
+                  keyCode,
+                  eventModifiers.rawValue,
+                  expectedFlags.rawValue)
+
+            // Check if modifiers match exactly
+            if eventModifiers == expectedFlags {
+                NSLog("🔔 KeyboardMonitor: %@ detected - MATCH!", currentHotkey.displayString)
+                DispatchQueue.main.async { [weak self] in
+                    self?.onTrigger?()
+                }
+            } else {
+                NSLog("❌ Modifier mismatch - expected 0x%lx, got 0x%lx", expectedFlags.rawValue, eventModifiers.rawValue)
             }
         }
     }
-    
+
     // MARK: - Cleanup
-    
+
     deinit {
         stopMonitoring()
     }

--- a/Sources/LookMaNoHands/Views/HotkeyRecorderView.swift
+++ b/Sources/LookMaNoHands/Views/HotkeyRecorderView.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+import AppKit
+
+/// State for the hotkey recording process
+enum HotkeyRecordingState: Equatable {
+    case idle
+    case recording
+    case invalid(String)
+}
+
+/// Raycast-style hotkey recorder view
+struct HotkeyRecorderView: View {
+    @Binding var hotkey: Hotkey?
+    @State private var recordingState: HotkeyRecordingState = .idle
+    @State private var localMonitor: Any?
+    @State private var globalMonitor: Any?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // Hotkey display box
+            Button(action: toggleRecording) {
+                HStack(spacing: 4) {
+                    if case .recording = recordingState {
+                        Text("Press hotkey...")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 12))
+                    } else if case .invalid(let message) = recordingState {
+                        Text(message)
+                            .foregroundColor(.red)
+                            .font(.system(size: 11))
+                    } else if let hk = hotkey {
+                        HotkeyDisplay(hotkey: hk)
+                    } else {
+                        Text("Click to record")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 12))
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .frame(minWidth: 120)
+                .background(recordingBackground)
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(recordingBorderColor, lineWidth: 1.5)
+                )
+            }
+            .buttonStyle(.plain)
+
+            // Clear button
+            if hotkey != nil && recordingState == .idle {
+                Button(action: clearHotkey) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 14))
+                }
+                .buttonStyle(.plain)
+                .help("Clear hotkey")
+            }
+        }
+        .onDisappear {
+            stopRecording()
+        }
+    }
+
+    private var recordingBackground: Color {
+        switch recordingState {
+        case .recording:
+            return Color.accentColor.opacity(0.1)
+        case .invalid:
+            return Color.red.opacity(0.1)
+        case .idle:
+            return Color(NSColor.controlBackgroundColor)
+        }
+    }
+
+    private var recordingBorderColor: Color {
+        switch recordingState {
+        case .recording:
+            return .accentColor
+        case .invalid:
+            return .red
+        case .idle:
+            return Color(NSColor.separatorColor)
+        }
+    }
+
+    private func toggleRecording() {
+        if case .recording = recordingState {
+            stopRecording()
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        guard recordingState == .idle else { return }
+        recordingState = .recording
+
+        // Install local event monitor for key events
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
+            self.handleKeyEvent(event)
+            return nil // Consume the event
+        }
+
+        // Also monitor for clicks outside to cancel
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { _ in
+            self.cancelRecording()
+        }
+    }
+
+    private func stopRecording() {
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        if case .recording = recordingState {
+            recordingState = .idle
+        }
+    }
+
+    private func cancelRecording() {
+        stopRecording()
+        recordingState = .idle
+    }
+
+    private func clearHotkey() {
+        hotkey = nil
+    }
+
+    private func handleKeyEvent(_ event: NSEvent) {
+        // Handle Escape to cancel
+        if event.keyCode == 53 { // Escape
+            cancelRecording()
+            return
+        }
+
+        let keyCode = UInt16(event.keyCode)
+
+        // Ignore flagsChanged events (modifier key presses alone)
+        // We only capture when a regular key is pressed with modifiers
+        if event.type == .flagsChanged {
+            return
+        }
+
+        // Regular key pressed - build the hotkey with modifiers
+        let modifiers = Hotkey.ModifierFlags(
+            command: event.modifierFlags.contains(.command),
+            shift: event.modifierFlags.contains(.shift),
+            option: event.modifierFlags.contains(.option),
+            control: event.modifierFlags.contains(.control)
+        )
+
+        let newHotkey = Hotkey(keyCode: keyCode, modifiers: modifiers)
+
+        // Validate the hotkey
+        if let error = validateHotkey(newHotkey) {
+            showError(error)
+            return
+        }
+
+        acceptHotkey(newHotkey)
+    }
+
+    private func validateHotkey(_ hotkey: Hotkey) -> String? {
+        // Check for reserved system hotkeys
+        if hotkey.isReserved {
+            return "Reserved by system"
+        }
+
+        // Predefined triggers (Caps Lock, Fn, Right Option) are always valid
+        // These are special system keys that work with single keypress
+        if hotkey.isPredefinedTrigger {
+            return nil
+        }
+
+        // For custom hotkeys: enforce 2-3 keypress rule
+        // Count keypresses: each modifier + the main key
+        let modifierCount = [
+            hotkey.modifiers.command,
+            hotkey.modifiers.shift,
+            hotkey.modifiers.option,
+            hotkey.modifiers.control
+        ].filter { $0 }.count
+
+        // Single modifier keys = 1 keypress (too few for custom hotkeys)
+        if hotkey.isSingleModifierKey {
+            return "Use preset or add key"
+        }
+
+        // Regular keys without modifiers = 1 keypress (too few)
+        if modifierCount == 0 {
+            return "Add a modifier key"
+        }
+
+        // More than 2 modifiers + 1 key = 4+ keypresses (too many)
+        if modifierCount > 2 {
+            return "Max 2 modifier keys"
+        }
+
+        return nil
+    }
+
+    private func showError(_ message: String) {
+        recordingState = .invalid(message)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            if case .invalid = self.recordingState {
+                self.recordingState = .recording
+            }
+        }
+    }
+
+    private func acceptHotkey(_ newHotkey: Hotkey) {
+        hotkey = newHotkey
+        stopRecording()
+        recordingState = .idle
+    }
+}
+
+/// Display a hotkey with styled key caps
+struct HotkeyDisplay: View {
+    let hotkey: Hotkey
+
+    var body: some View {
+        HStack(spacing: 2) {
+            // Modifiers first
+            if hotkey.modifiers.control {
+                KeyCapView(text: "⌃")
+            }
+            if hotkey.modifiers.option {
+                KeyCapView(text: "⌥")
+            }
+            if hotkey.modifiers.shift {
+                KeyCapView(text: "⇧")
+            }
+            if hotkey.modifiers.command {
+                KeyCapView(text: "⌘")
+            }
+            // Then the key
+            KeyCapView(text: Hotkey.keyCodeToString(hotkey.keyCode))
+        }
+    }
+}
+
+/// Styled key cap appearance
+struct KeyCapView: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium, design: .rounded))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 3)
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+            )
+            .shadow(color: Color.black.opacity(0.1), radius: 0.5, x: 0, y: 0.5)
+    }
+}
+
+// Preview removed for SPM compatibility - use Xcode previews if needed

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -158,6 +158,22 @@ struct SettingsView: View {
                         Text(key.rawValue).tag(key)
                     }
                 }
+                .onChange(of: settings.triggerKey) { _, newValue in
+                    // Post notification when trigger key changes
+                    NotificationCenter.default.post(name: .hotkeyConfigurationChanged, object: nil)
+                }
+
+                // Show HotkeyRecorderView when custom is selected
+                if settings.triggerKey == .custom {
+                    HStack {
+                        Text("Custom Hotkey")
+                        Spacer()
+                        HotkeyRecorderView(hotkey: $settings.customHotkey)
+                            .onChange(of: settings.customHotkey) { _, _ in
+                                NotificationCenter.default.post(name: .hotkeyConfigurationChanged, object: nil)
+                            }
+                    }
+                }
 
                 Text("Press this key to start and stop recording")
                     .font(.caption)

--- a/docs/enable-custom-hotkeys.md
+++ b/docs/enable-custom-hotkeys.md
@@ -1,0 +1,102 @@
+# Custom Hotkey Support Implementation Plan
+
+## Overview
+
+Add Raycast-style custom hotkey recording to Look Ma No Hands, allowing users to configure any key or key combination as their dictation trigger.
+
+## Current State
+
+- `KeyboardMonitor.swift` uses CGEvent APIs but only detects Caps Lock (keycode 57)
+- `Settings.swift` has a `TriggerKey` enum with 3 predefined options that don't actually affect monitoring
+- Menu bar shows hardcoded "Caps Lock" text
+
+## Implementation
+
+### 1. Create Hotkey Data Model
+
+**New file:** `Sources/LookMaNoHands/Models/Hotkey.swift`
+
+- `Hotkey` struct with `keyCode: UInt16` and `modifiers: ModifierFlags`
+- `ModifierFlags` nested struct (command, shift, option, control booleans)
+- Codable for UserDefaults persistence
+- `displayString` computed property (e.g., "Cmd+Shift+R")
+- `cgEventFlags` conversion for event matching
+- Static presets: `.capsLock`, `.rightOption`, `.fn`
+- Key code to string mapping dictionary
+
+### 2. Update Settings.swift
+
+- Add `customHotkey: Hotkey?` published property with UserDefaults persistence
+- Add `"customHotkey"` to Keys enum
+- Add `.custom` case to `TriggerKey` enum
+- Add `effectiveHotkey: Hotkey` computed property that returns the active hotkey
+- Add `toHotkey()` method on TriggerKey to convert enum to Hotkey
+
+### 3. Create HotkeyRecorderView
+
+**New file:** `Sources/LookMaNoHands/Views/HotkeyRecorderView.swift`
+
+UI Component (Raycast-style):
+- Displays current hotkey as styled key caps
+- Click to enter recording mode ("Press hotkey...")
+- Uses `NSEvent.addLocalMonitorForEvents` for key capture
+- Escape cancels recording
+- Click outside cancels recording
+- Visual states: idle (gray border), recording (blue border), invalid (red border)
+
+Validation:
+- **2-3 Keypress Rule**: Custom hotkeys must use 2-3 keypresses total
+  - Valid: 1 modifier + 1 key (Cmd+D) or 2 modifiers + 1 key (Cmd+Shift+D)
+  - Invalid: Single keys (A), single modifiers (Caps Lock), or 3+ modifiers
+  - Predefined triggers (Caps Lock, Fn, Right Option) are exempt from this rule
+- Block system-reserved shortcuts (Cmd+Q, Cmd+W, Cmd+Tab, Cmd+Space, etc.)
+- Require modifier for non-modifier keys (prevent accidental "A" as hotkey)
+- Show error message briefly before returning to recording state
+
+### 4. Update KeyboardMonitor.swift
+
+- Add `hotkey: Hotkey` property with thread-safe getter/setter
+- Add `setHotkey(_ newHotkey: Hotkey)` method for runtime updates
+- Update `startMonitoring()` to accept a `Hotkey` parameter
+- Modify event mask: monitor both `flagsChanged` AND `keyDown` events
+- Update `handleEvent()`:
+  - For single modifier keys (Caps Lock): check keycode on flagsChanged
+  - For key+modifier combos: check keycode AND modifier flags on keyDown
+  - Use `CGEventFlags` intersection to match only relevant modifiers
+
+### 5. Update SettingsView.swift Recording Tab
+
+- Change trigger key picker to use updated TriggerKey enum
+- Add conditional `HotkeyRecorderView` when `.custom` is selected
+- Add `onChange` handlers to post `hotkeyConfigurationChanged` notification
+- Add `Notification.Name.hotkeyConfigurationChanged` extension
+
+### 6. Update AppDelegate.swift
+
+- Modify `setupKeyboardMonitoring()` to use `Settings.shared.effectiveHotkey`
+- Add observer for `hotkeyConfigurationChanged` notification
+- Add `hotkeyConfigurationDidChange()` handler that calls `keyboardMonitor.setHotkey()`
+- Update menu item text dynamically based on `effectiveHotkey.displayString`
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `Sources/LookMaNoHands/Models/Hotkey.swift` | **NEW** - Data model |
+| `Sources/LookMaNoHands/Models/Settings.swift` | Add customHotkey, effectiveHotkey |
+| `Sources/LookMaNoHands/Views/HotkeyRecorderView.swift` | **NEW** - UI component |
+| `Sources/LookMaNoHands/Views/SettingsView.swift` | Integrate recorder |
+| `Sources/LookMaNoHands/Services/KeyboardMonitor.swift` | Dynamic hotkey support |
+| `Sources/LookMaNoHands/App/AppDelegate.swift` | Wire up notifications |
+
+## Verification
+
+1. Build: `./deploy.sh`
+2. Open Settings > Recording tab
+3. Test predefined options (Caps Lock, Right Option, Fn)
+4. Select "Custom..." and record a hotkey (e.g., Cmd+Shift+D)
+5. Verify the custom hotkey triggers recording
+6. Verify menu bar shows correct hotkey name
+7. Quit and relaunch - verify setting persists
+8. Test validation: try reserved shortcuts (Cmd+Q), verify rejection
+9. Test cancel: press Escape during recording, verify it cancels


### PR DESCRIPTION
Features:
- Raycast-style hotkey recorder UI with real-time validation
- Support for custom key combinations (1-2 modifiers + key)
- Predefined triggers (Caps Lock, Right Option, Fn) exempt from validation
- System-reserved hotkey blocking (Cmd+Q, Cmd+W, etc.)
- Dynamic hotkey switching without app restart
- Persistent storage via UserDefaults

Fixes:
- Right Option key now triggers once (not double-trigger)
- Caps Lock works immediately after selection change
- Proper modifier key state tracking to prevent flash/flicker