### PR TITLE
Security: Redact transcription content from crash reports

### DIFF
--- a/Sources/LookMaNoHands/Services/CrashReporter.swift
+++ b/Sources/LookMaNoHands/Services/CrashReporter.swift
@@ -156,7 +156,7 @@ final class CrashReporter {
 
         if let lastTranscription = state.lastTranscription {
             report += """
-        Last Transcription: \(lastTranscription.prefix(500))...
+        Last Transcription: [REDACTED - \(lastTranscription.count) characters]
 
         """
         }


### PR DESCRIPTION
## Summary
Fix medium-severity data exposure vulnerability in crash reporting.

## Problem
User-dictated text (potentially containing passwords, PII, or confidential information) was logged in plaintext to crash reports at `~/Library/Logs/LookMaNoHands/crashes/`.

## Solution
Replace full transcription content with character count metadata:
- Before: `Last Transcription: <actual sensitive text>...`
- After: `Last Transcription: [REDACTED - 247 characters]`

## Impact
- ✅ Eliminates privacy risk from persistent unencrypted logs
- ✅ Maintains debugging utility (transcription length still visible)
- ✅ Follows data minimization principle

## Security Details
- **Severity**: Medium
- **Category**: Data Exposure
- **Confidence**: 9/10
- **Files Changed**: 1 file, 1 line

## Testing
Crash reports will now show `[REDACTED - N characters]` instead of actual transcription content while preserving diagnostic information about transcription length and timing.

Generated with [Claude Code](https://claude.com/claude-code)