### PR TITLE
Add real-time permission status updates in Settings

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -77,6 +77,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSLog("✅ AppDelegate: Menu bar setup complete")
 
         // Check if first launch (but not if we just completed onboarding in this session)
+        NSLog("🔍 Onboarding check: hasCompletedOnboarding=%@, justCompletedOnboarding=%@",
+              Settings.shared.hasCompletedOnboarding ? "true" : "false",
+              justCompletedOnboarding ? "true" : "false")
+
         if !Settings.shared.hasCompletedOnboarding && !justCompletedOnboarding {
             NSLog("🆕 First launch detected - showing onboarding")
             showOnboarding()
@@ -100,13 +104,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Onboarding
 
     private func showOnboarding() {
+        NSLog("🎬 showOnboarding() - Creating onboarding window")
+
         // Switch to regular app mode so window appears in Dock and Cmd+Tab
         NSApp.setActivationPolicy(.regular)
+        NSLog("   ✓ Set activation policy to .regular")
 
         let onboardingView = OnboardingView(
             whisperService: whisperService,
             ollamaService: ollamaService,
             onComplete: {
+                NSLog("🎬 Onboarding onComplete callback triggered")
+
                 // Called when user clicks "Finish"
                 self.onboardingWindow?.close()
                 self.onboardingWindow = nil
@@ -129,8 +138,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         )
+        NSLog("   ✓ Created OnboardingView")
 
         let hostingController = NSHostingController(rootView: onboardingView)
+        NSLog("   ✓ Created NSHostingController")
 
         let window = NSWindow(contentViewController: hostingController)
         window.title = "Welcome to Look Ma No Hands"
@@ -138,15 +149,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.center()
         window.isReleasedWhenClosed = false
         window.level = .floating
+        NSLog("   ✓ Configured NSWindow")
 
         self.onboardingWindow = window
 
         // Bring window to front and activate app
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        NSLog("   ✓ Made window key and front")
 
         // Ensure window stays on top
         window.orderFrontRegardless()
+        NSLog("✅ Onboarding window should now be visible")
     }
 
     private func completeInitialization() {
@@ -942,18 +956,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            // Reset onboarding status
-            Settings.shared.hasCompletedOnboarding = false
-
             // Clear UserDefaults for this app
             if let bundleID = Bundle.main.bundleIdentifier {
+                NSLog("🔄 Developer Reset: Clearing UserDefaults for bundle: %@", bundleID)
                 UserDefaults.standard.removePersistentDomain(forName: bundleID)
                 UserDefaults.standard.synchronize()
+            } else {
+                NSLog("⚠️ Developer Reset: No bundle identifier found!")
             }
 
             // Note: Cannot programmatically revoke system permissions (microphone, accessibility, screen recording)
             // User must manually revoke these in System Settings if needed
-            print("Developer reset complete - app will now restart")
+            NSLog("✅ Developer reset complete - app will now restart")
 
             // Restart the app to show onboarding
             restartApp()

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -341,8 +341,10 @@ Now produce the complete meeting notes following the format above. Ensure every 
         // Onboarding completion defaults to false for new users
         if UserDefaults.standard.object(forKey: Keys.hasCompletedOnboarding) != nil {
             self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: Keys.hasCompletedOnboarding)
+            NSLog("📖 Settings: Loaded hasCompletedOnboarding from UserDefaults: %@", self.hasCompletedOnboarding ? "true" : "false")
         } else {
             self.hasCompletedOnboarding = false
+            NSLog("📖 Settings: No saved onboarding status - defaulting to false (first launch)")
         }
     }
     

--- a/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
+++ b/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
@@ -51,17 +51,23 @@ class KeyboardMonitor {
     /// - Parameters:
     ///   - hotkey: The hotkey to monitor for (defaults to Caps Lock)
     ///   - callback: Called when the trigger key is pressed
+    ///   - showPrompt: Whether to show the system permission prompt if not granted (defaults to false)
     /// - Returns: True if monitoring started successfully
     @discardableResult
-    func startMonitoring(hotkey: Hotkey = .capsLock, onTrigger callback: @escaping TriggerCallback) -> Bool {
+    func startMonitoring(hotkey: Hotkey = .capsLock, showPrompt: Bool = false, onTrigger callback: @escaping TriggerCallback) -> Bool {
         guard !isMonitoring else { return true }
 
-        // Check accessibility permission and prompt if needed
-        let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
-        let trusted = AXIsProcessTrustedWithOptions(options)
+        // Check accessibility permission (optionally prompting)
+        let trusted: Bool
+        if showPrompt {
+            let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
+            trusted = AXIsProcessTrustedWithOptions(options)
+        } else {
+            trusted = AXIsProcessTrusted()
+        }
 
         guard trusted else {
-            print("KeyboardMonitor: Accessibility permission not granted - prompt shown")
+            print("KeyboardMonitor: Accessibility permission not granted\(showPrompt ? " - prompt shown" : "")")
             return false
         }
 


### PR DESCRIPTION
## Summary
Implements automatic polling of permission status when viewing the Permissions tab, eliminating the need for manual refresh. Permission status now updates every second while the tab is active, providing immediate feedback when users grant permissions through System Settings.

Additionally includes comprehensive Settings UI improvements across all tabs for better user experience.

## Changes by File

### SettingsView.swift
**Permission Polling:**
- Added Timer-based permission polling that activates only when Permissions tab is selected
- Automatically starts/stops based on tab selection and view lifecycle
- Removed manual "Refresh Permission Status" button (replaced with auto-update message)

**Layout Improvements:**
- Wrapped content area in ScrollView for better layout flexibility
- Increased window size from 550x400 to 550x450 (minHeight)

**General Tab:**
- Renamed "Display" section to "Recording Indicator"
- Added tooltips (.help) throughout for better UX
- Improved help text descriptions to be more descriptive
- Changed "Reset to Defaults" button to have destructive role
- Added icon to "Run Setup Wizard Again" button
- Better spacing and layout with Divider elements

**Recording Tab:**
- Added help text explaining Ollama model is currently fixed
- Improved layout and spacing

**Permissions Tab:**
- Changed Accessibility button text from "Grant" to "Open Settings"
- Added contextual help text for permission buttons
- Shows "Permission status updates automatically" message
- Removed manual refresh button (now automatic)

**About Tab:**
- Enhanced with features list showing key capabilities
- Added "Powered By" section with links to Whisper.cpp, Ollama, and GitHub
- Better visual layout with FeatureListItem component
- Changed tagline to "Fast, local voice dictation for macOS"

**New Components:**
- Added FeatureListItem helper view for consistent feature display

### KeyboardMonitor.swift
- Added `showPrompt` parameter to `startMonitoring()` method
- Allows controlled permission prompting (defaults to false)
- Only shows system permission dialog when explicitly requested
- Improves UX by not showing unexpected permission prompts

### AppDelegate.swift
**Enhanced Logging:**
- Added detailed NSLog statements in showOnboarding() method:
  - Tracks onboarding window creation steps
  - Logs activation policy changes
  - Confirms window visibility
  
**Developer Reset:**
- Better logging of reset process
- More robust error handling for bundle ID
- Clearer log messages with emojis for visibility

**Onboarding Flow:**
- Fixed onboarding status check logging
- Added debug output for troubleshooting first-launch issues

### Settings.swift
- Added logging for hasCompletedOnboarding loading
- Logs when value is loaded from UserDefaults vs. defaulting to false
- Helps debug first-launch and onboarding state issues

## Test Plan
- [x] Open Settings → Permissions tab
- [x] Verify permission statuses are displayed correctly
- [x] Grant microphone permission in System Settings
- [x] Confirm status updates automatically within 1 second
- [x] Switch to different tab - verify polling stops
- [x] Return to Permissions tab - verify polling resumes
- [x] Close Settings window - verify no memory leaks
- [x] Verify all UI improvements across General, Recording, Models, Permissions, and About tabs
- [x] Test tooltips and help text display correctly
- [x] Verify ScrollView works properly with content

## Fixes
Closes #16