### PR TITLE
Redesign Meeting Transcription window

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -353,18 +353,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Create meeting window
+        // Create meeting window with improved dimensions
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
 
-        window.title = "Meeting Transcription"
+        window.title = "Look Ma No Hands - Meeting Transcription"
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 600, height: 400)
+        window.minSize = NSSize(width: 600, height: 450)
+        window.maxSize = NSSize(width: 1400, height: 1200)
+        window.setFrameAutosaveName("MeetingTranscriptionWindow")
         window.delegate = self
 
         // Create SwiftUI meeting view and wrap it in NSHostingView

--- a/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
@@ -173,4 +173,12 @@ class MixedAudioRecorder {
 
         return normalized
     }
+
+    // MARK: - Frequency Visualization
+
+    /// Get frequency bands for waveform visualization
+    /// Delegates to microphone recorder since that's the primary audio source for visualization
+    func getFrequencyBands(bandCount: Int) -> [Float] {
+        return microphoneRecorder.getFrequencyBands(bandCount: bandCount)
+    }
 }

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -6,6 +6,7 @@ import Combine
 struct WaveformBarsView: View {
     @Binding var frequencyBands: [Float]
     @Environment(\.colorScheme) var colorScheme
+    var fixedWidth: CGFloat? = nil  // Optional fixed width for floating indicator
 
     var body: some View {
         Canvas { context, size in
@@ -49,7 +50,7 @@ struct WaveformBarsView: View {
                 context.fill(path, with: .color(color.opacity(colorScheme == .dark ? 0.8 : 0.9)))
             }
         }
-        .frame(width: 300, height: 38)
+        .frame(width: fixedWidth, height: 38)
     }
 }
 
@@ -63,7 +64,7 @@ struct RecordingIndicator: View {
 
     var body: some View {
         // Just the waveform visualization
-        WaveformBarsView(frequencyBands: $state.frequencyBands)
+        WaveformBarsView(frequencyBands: $state.frequencyBands, fixedWidth: 300)
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(
@@ -311,12 +312,20 @@ class RecordingIndicatorWindowController {
 
     /// Start periodic position updates
     private func startPositionUpdates() {
-        // Update position every 200ms while recording
-        positionUpdateTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak self] _ in
+        // Update position every 100ms to smoothly follow mouse cursor
+        positionUpdateTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
-            if let cursorRect = CursorPositionService.shared.getCursorScreenPosition() {
-                self.updatePosition(for: cursorRect)
-            }
+
+            // Always use mouse cursor position for smooth tracking
+            let mouseLocation = NSEvent.mouseLocation
+            let cursorRect = NSRect(
+                x: mouseLocation.x,
+                y: mouseLocation.y,
+                width: 2,
+                height: 20
+            )
+
+            self.updatePosition(for: cursorRect)
         }
     }
 


### PR DESCRIPTION
## Meeting Transcription Window Improvements

### UI Redesign
- Updated window title to "Look Ma No Hands - Meeting Transcription"
- Redesigned header with meeting title (auto-generated from date/time) and status badge
- Added recording visualization area with live waveform during recording
- Implemented recording session bars showing completed recordings (8px gap, clickable)
- Made transcript collapsible with fixed 200px height to prevent window scrolling
- Moved Clear button inside transcript frame
- Redesigned bottom action buttons with uniform sizing (120px × 32px)

### Recording Session Management
- Added RecordingSession model to track multiple recording segments
- Implemented segment highlighting when clicking recording bars
- Added auto-scroll to selected session's transcript segments
- Toggle selection by clicking recording bar again to deselect
- Visual highlighting with blue background tint and blue timestamp text

### Export Button Fix
- Replaced Menu-based Export button with Button + popover for consistent styling
- Export button now matches Summary and Settings button appearance
- Popover contains all export options (transcript, timestamped, notes)
- Auto-dismisses after action selection

### Waveform Improvements
- Added exponential smoothing (70% old + 30% new) for fluid animation
- Applied power 2.5 amplitude scaling for better dynamic range
- Made WaveformBarsView accept optional fixedWidth parameter
- Full-width waveform in meeting window, 300px in floating indicator

### Bug Fixes
- Fixed crash when stopping second recording (Range validation)
- Fixed transcript scrolling causing entire window to scroll
- Fixed recording button color (now red when ready)
- Fixed waveform not extending full horizontal width

## Dictation Mode Improvements

### Floating Indicator Mouse Tracking
- Changed floating indicator to follow mouse cursor in real-time
- Reduced update interval to 100ms for smooth tracking
- Simplified positioning logic to always use NSEvent.mouseLocation
- Indicator now consistently follows mouse movement throughout recording

### Technical Changes
- Added MixedAudioRecorder.getFrequencyBands() for visualization support
- Window dimensions: 800×600 (min: 600×450, max: 1400×1200)
- Window position persists via setFrameAutosaveName