### PR TITLE
Add ESC key cancellation for dictation recording

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -587,6 +587,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.handleTriggerKey()
         }
 
+        // Set up ESC key cancellation callback
+        keyboardMonitor.setCancellationCallback { [weak self] in
+            self?.handleCancelKey()
+        }
+
         if success {
             NSLog("✅ Keyboard monitoring started successfully")
         } else {
@@ -644,6 +649,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             print("Ignoring trigger - currently processing")
         }
+    }
+
+    /// Handle ESC key press - cancels recording without transcribing
+    private func handleCancelKey() {
+        NSLog("⎋ ESC key pressed - canceling recording")
+
+        guard transcriptionState.isRecording else {
+            NSLog("⎋ Not recording - ignoring ESC key")
+            return
+        }
+
+        // Stop the audio recorder without saving (discard samples)
+        _ = audioRecorder.stopRecording()
+
+        // Update state to idle (skips processing)
+        transcriptionState.cancelRecording()
+
+        // Update UI
+        updateMenuBarIcon(isRecording: false)
+        recordingIndicator.hide()
+
+        NSLog("✅ Recording canceled - no text will be inserted")
     }
 
     /// Start recording audio

--- a/Sources/LookMaNoHands/Models/TranscriptionState.swift
+++ b/Sources/LookMaNoHands/Models/TranscriptionState.swift
@@ -96,6 +96,14 @@ class TranscriptionState {
         guard recordingState == .recording else { return }
         recordingState = .processing
     }
+
+    /// Cancel recording without processing (ESC key pressed)
+    func cancelRecording() {
+        guard recordingState == .recording else { return }
+        recordingState = .idle
+        rawTranscription = nil
+        formattedText = nil
+    }
     
     /// Set the raw transcription result
     func setTranscription(_ text: String) {


### PR DESCRIPTION
## Summary
Implements ESC key cancellation for dictation recording sessions (fixes #31).

## Changes
- **KeyboardMonitor.swift**: Added ESC key (keyCode 53) detection and cancellation callback mechanism
- **TranscriptionState.swift**: Added `cancelRecording()` method for clean state transition from recording → idle
- **AppDelegate.swift**: Added `handleCancelKey()` handler to stop recording and discard audio without transcription

## Behavior
When the user presses **ESC** during an active recording:
1. Audio recording stops immediately
2. Recording indicator window disappears
3. Application state returns to idle (skipping processing phase)
4. **No text is transcribed or inserted** into the active application

## Testing
- ✅ Project builds successfully with no new errors or warnings
- ✅ Follows existing code patterns (thread-safe, weak references, proper logging)
- ✅ State machine transitions are properly guarded

## Usage
1. Press Caps Lock (or configured hotkey) to start recording
2. Press ESC to cancel → no text will be inserted
3. Or press Caps Lock again to complete recording → text will be transcribed and inserted

Closes #31