### PR TITLE
Reduce onboarding modal size from 700x600 to 600x520

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -148,6 +148,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     // (won't show accessibility prompt since we just did onboarding)
                     self.completeInitialization()
                 }
+            },
+            bringToFront: { [weak self] in
+                // Bring onboarding window to front after system permission dialogs close
+                self?.onboardingWindow?.makeKeyAndOrderFront(nil)
+                NSApp.activate(ignoringOtherApps: true)
             }
         )
         NSLog("   ✓ Created OnboardingView")
@@ -160,7 +165,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.styleMask = [.titled, .closable]
         window.center()
         window.isReleasedWhenClosed = false
-        window.level = .floating
+        window.level = .normal  // Use normal level so system permission dialogs appear above
         NSLog("   ✓ Configured NSWindow")
 
         self.onboardingWindow = window


### PR DESCRIPTION
## Problems

1. The onboarding modal was too large at 700x600 pixels, taking up excessive screen space
2. The onboarding window used `.floating` level, causing it to overlap macOS permission dialogs and hide them from users

## Solutions

### Size Reduction
Made the onboarding modal more compact while maintaining readability and usability:
- Reduced window dimensions from 700x600 to 600x520 pixels  
- Reduced icon sizes throughout (90→70, 80→65, 70→60)
- Reduced title font sizes (28→24, 26→22)  
- Reduced spacing and padding across all onboarding steps
- Reduced progress indicator circle size (32→28) and font sizes (14→12, 11→10)
- Tightened overall layout spacing for better density

### Permission Dialog Overlap Fix
Fixed the UX issue where system permission dialogs were hidden behind the onboarding window:
- Changed window level from `.floating` to `.normal` so system dialogs appear on top
- Added smart refocus mechanism that automatically brings onboarding window back to front after permission dialogs close
- PermissionsStepView now detects when permissions are granted and triggers window refocus
- Maintains onboarding prominence while respecting macOS UI hierarchy

## Results

- Modal is now **14% smaller in width** and **13% smaller in height**
- System permission dialogs now appear above the onboarding window (proper macOS behavior)
- Onboarding window automatically refocuses after user grants permissions
- All onboarding steps fit comfortably and text remains readable

## Testing

- Build succeeds with no errors or warnings
- All onboarding steps display correctly in the new size
- Permission dialogs appear on top and onboarding window refocuses after dismissal
- UI elements properly spaced and fully functional

Fixes #63