### PR TITLE
Fix crash in vocabulary tab from stale ForEach indices

### DIFF
--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -349,31 +349,22 @@ struct SettingsView: View {
                 .padding(.horizontal, 4)
 
                 // Entries
-                ForEach(Array(settings.customVocabulary.enumerated()), id: \.element.id) { index, entry in
+                ForEach($settings.customVocabulary) { $entry in
                     HStack(spacing: 8) {
-                        TextField("e.g. swift ui", text: Binding(
-                            get: { settings.customVocabulary[index].phrase },
-                            set: { settings.customVocabulary[index].phrase = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 160)
+                        TextField("e.g. swift ui", text: $entry.phrase)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 160)
 
-                        TextField("e.g. SwiftUI", text: Binding(
-                            get: { settings.customVocabulary[index].replacement },
-                            set: { settings.customVocabulary[index].replacement = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 160)
+                        TextField("e.g. SwiftUI", text: $entry.replacement)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 160)
 
-                        Toggle("", isOn: Binding(
-                            get: { settings.customVocabulary[index].enabled },
-                            set: { settings.customVocabulary[index].enabled = $0 }
-                        ))
-                        .toggleStyle(.checkbox)
-                        .labelsHidden()
+                        Toggle("", isOn: $entry.enabled)
+                            .toggleStyle(.checkbox)
+                            .labelsHidden()
 
                         Button(role: .destructive) {
-                            settings.customVocabulary.remove(at: index)
+                            settings.customVocabulary.removeAll { $0.id == entry.id }
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary

- Fixes a SIGTRAP crash in the Settings vocabulary tab caused by index-based `Binding` closures going stale during SwiftUI's view update cycle after deleting an entry
- Replaces `ForEach(Array(enumerated()))` with projected bindings (`ForEach($settings.customVocabulary) { $entry in ... }`) for safe, identity-based access
- Uses `removeAll(where:)` by ID instead of `remove(at: index)` to avoid stale index references

## Test plan

- [ ] Open Settings > Vocabulary tab
- [ ] Add several vocabulary entries and verify text fields and toggles work
- [ ] Delete entries (first, middle, last) and confirm no crash
- [ ] Rapidly add and delete entries to stress test the view update cycle

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)