### PR TITLE
Eliminate autonomous network checks

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -457,28 +457,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Ollama Check
-
-    private func checkOllamaStatus() {
-        Task {
-            let available = await ollamaService.isAvailable()
-            await MainActor.run {
-                transcriptionState.isOllamaAvailable = available
-                print("Ollama status: \(available ? "Available" : "Not available")")
-
-                // Update menu item
-                if let menu = statusItem?.menu {
-                    for item in menu.items {
-                        if item.title.starts(with: "Ollama:") {
-                            item.title = "Ollama: \(available ? "✓ Running" : "✗ Not running")"
-                            break
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     // MARK: - Whisper Model Loading
 
     private func loadWhisperModel() {

--- a/Sources/LookMaNoHands/Views/OnboardingView.swift
+++ b/Sources/LookMaNoHands/Views/OnboardingView.swift
@@ -215,7 +215,8 @@ struct OllamaStepView: View {
     let ollamaService: OllamaService
 
     @State private var ollamaInstalled: Bool = false
-    @State private var isChecking: Bool = true
+    @State private var isChecking: Bool = false
+    @State private var hasChecked: Bool = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -273,11 +274,11 @@ struct OllamaStepView: View {
                             Label("Copy Commands", systemImage: "doc.on.doc")
                         }
 
-                        // Check again button
+                        // Check status button
                         Button(action: {
                             checkOllama()
                         }) {
-                            Label("Check Again", systemImage: "arrow.clockwise")
+                            Label(hasChecked ? "Check Again" : "Check Status", systemImage: "arrow.clockwise")
                         }
                         .buttonStyle(.bordered)
                     }
@@ -289,9 +290,6 @@ struct OllamaStepView: View {
         }
         .padding(.horizontal, 40)
         .padding(.vertical, 15)
-        .onAppear {
-            checkOllama()
-        }
     }
 
     private func checkOllama() {
@@ -301,6 +299,7 @@ struct OllamaStepView: View {
             await MainActor.run {
                 ollamaInstalled = available
                 isChecking = false
+                hasChecked = true
             }
         }
     }

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -59,7 +59,6 @@ struct SettingsView: View {
         .frame(minWidth: 750, minHeight: 450)
         .onAppear {
             checkPermissions()
-            checkOllamaStatus()
             checkWhisperModelStatus()
             // Start permission polling if on permissions tab
             if selectedTab == .permissions {
@@ -1229,10 +1228,10 @@ enum ConnectionState {
     case checking
     case connected
     case disconnected
-    
+
     var description: String {
         switch self {
-        case .unknown: return "Unknown"
+        case .unknown: return "Not checked"
         case .checking: return "Checking..."
         case .connected: return "Connected"
         case .disconnected: return "Not Running"


### PR DESCRIPTION
Resolves #66

Remove automatic Ollama status checks that ran on app launch and in settings, making them user-initiated only. Add Core ML download allowlist to prevent unnecessary network requests for models without Core ML support. Update UI labels to accurately reflect "not checked" state instead of unknown.

These changes strengthen the app's privacy-first philosophy by eliminating background network activity while preserving necessary user-triggered functionality.