### PR TITLE
Add release packaging with DMG creation and GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build DMG
+        run: ./scripts/create-dmg.sh "${{ steps.version.outputs.VERSION }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/LookMaNoHands-${{ steps.version.outputs.VERSION }}.dmg
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Swift build artifacts
 .build/
+build/
 *.xcodeproj
 *.xcworkspace
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>13.0</string>
+	<string>14.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+APP_NAME="Look Ma No Hands"
+BUNDLE_ID="com.lookmanohands.app"
+VERSION="${1:-1.0}"
+DMG_NAME="LookMaNoHands-${VERSION}.dmg"
+BUILD_DIR="build"
+APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
+
+echo "Building ${APP_NAME} v${VERSION}..."
+swift build -c release
+
+echo "Creating app bundle..."
+rm -rf "${APP_PATH}"
+mkdir -p "${APP_PATH}/Contents/MacOS"
+mkdir -p "${APP_PATH}/Contents/Resources"
+
+# Copy binary
+cp ".build/release/LookMaNoHands" "${APP_PATH}/Contents/MacOS/LookMaNoHands"
+chmod +x "${APP_PATH}/Contents/MacOS/LookMaNoHands"
+
+# Copy Info.plist
+cp "Resources/Info.plist" "${APP_PATH}/Contents/Info.plist"
+
+# Copy icon
+if [ -f "Resources/AppIcon.icns" ]; then
+    cp "Resources/AppIcon.icns" "${APP_PATH}/Contents/Resources/AppIcon.icns"
+fi
+
+# Ad-hoc code sign
+codesign --force --sign - "${APP_PATH}"
+
+echo "Creating DMG..."
+rm -f "${BUILD_DIR}/${DMG_NAME}"
+
+# Create temporary DMG directory
+DMG_TEMP="${BUILD_DIR}/dmg-temp"
+rm -rf "${DMG_TEMP}"
+mkdir -p "${DMG_TEMP}"
+cp -R "${APP_PATH}" "${DMG_TEMP}/"
+ln -s /Applications "${DMG_TEMP}/Applications"
+
+# Create DMG
+hdiutil create -volname "${APP_NAME}" \
+    -srcfolder "${DMG_TEMP}" \
+    -ov -format UDZO \
+    "${BUILD_DIR}/${DMG_NAME}"
+
+# Clean up
+rm -rf "${DMG_TEMP}"
+
+echo "DMG created: ${BUILD_DIR}/${DMG_NAME}"


### PR DESCRIPTION
## Summary
- Adds `scripts/create-dmg.sh` that builds the release binary, bundles it into a `.app` structure, ad-hoc signs it, and packages into a DMG with Applications symlink for drag-and-drop install
- Adds GitHub Actions workflow (`.github/workflows/release.yml`) triggered on version tags (e.g. `v1.0`) that builds the DMG and creates a GitHub Release
- Updates `.gitignore` to exclude the `build/` directory used by the DMG script
- Bumps `LSMinimumSystemVersion` in `Info.plist` from 13.0 to 14.0 to align with the documented macOS 14+ (Sonoma) requirement for `@Observable`

Closes #75

## Test plan
- [ ] Run `./scripts/create-dmg.sh` locally and verify DMG is created in `build/`
- [ ] Mount the DMG and verify the app launches
- [ ] Verify the Applications symlink is present for drag-and-drop install
- [ ] Push a version tag to test the GitHub Actions workflow