### PR TITLE
Fix release workflow permissions and DMG filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: macos-14
@@ -21,5 +24,5 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: build/LookMaNoHands-${{ steps.version.outputs.VERSION }}.dmg
+          files: "build/Look Ma No Hands ${{ steps.version.outputs.VERSION }}.dmg"
           generate_release_notes: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,6 +47,10 @@ rm -rf ~/Library/Caches/com.apple.iconservices.store
 killall Dock 2>/dev/null || true
 killall Finder 2>/dev/null || true
 
+# Reset app settings so onboarding shows on launch
+echo "🧹 Clearing app defaults..."
+defaults delete com.lookmanohands.app 2>/dev/null || true
+
 echo "✅ Deployed! Launching app..."
 open "$APP_PATH"
 

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -4,7 +4,7 @@ set -e
 APP_NAME="Look Ma No Hands"
 BUNDLE_ID="com.lookmanohands.app"
 VERSION="${1:-1.0}"
-DMG_NAME="LookMaNoHands-${VERSION}.dmg"
+DMG_NAME="Look Ma No Hands ${VERSION}.dmg"
 BUILD_DIR="build"
 APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
 


### PR DESCRIPTION
## Summary
- Adds `contents: write` permission to the release workflow so it can create GitHub Releases (fixes "Resource not accessible by integration" error)
- Updates DMG filename to use spaces matching the app name (`Look Ma No Hands 1.0.dmg`)
- Resets app defaults in `deploy.sh` so onboarding shows on every local deploy for testing

Relates to #75

## Test plan
- [ ] Delete the existing `v1.0` tag and re-push it to trigger the workflow
- [ ] Verify the GitHub Actions workflow completes successfully
- [ ] Verify a GitHub Release is created with the correctly named DMG
- [ ] Run `./deploy.sh` and verify onboarding appears