### PR TITLE
Add version check and update mechanism

### DIFF
--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -239,6 +239,8 @@ Now produce the complete meeting notes following the format above. Ensure every 
         static let indicatorPosition = "indicatorPosition"
         static let showLaunchConfirmation = "showLaunchConfirmation"
         static let customVocabulary = "customVocabulary"
+        static let checkForUpdatesOnLaunch = "checkForUpdatesOnLaunch"
+        static let lastUpdateCheckDate = "lastUpdateCheckDate"
     }
     
     // MARK: - Audio Device Manager
@@ -331,6 +333,25 @@ Now produce the complete meeting notes following the format above. Ensure every 
         }
     }
 
+    /// Whether to automatically check for updates on launch (opt-in, default off)
+    @Published var checkForUpdatesOnLaunch: Bool {
+        didSet {
+            UserDefaults.standard.set(checkForUpdatesOnLaunch, forKey: Keys.checkForUpdatesOnLaunch)
+        }
+    }
+
+    /// Date of the last successful update check
+    var lastUpdateCheckDate: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.lastUpdateCheckDate) as? Date }
+        set {
+            if let date = newValue {
+                UserDefaults.standard.set(date, forKey: Keys.lastUpdateCheckDate)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Keys.lastUpdateCheckDate)
+            }
+        }
+    }
+
     // MARK: - Initialization
     
     private init() {
@@ -390,6 +411,13 @@ Now produce the complete meeting notes following the format above. Ensure every 
             self.customVocabulary = []
         }
 
+        // Auto-update check defaults to false (opt-in)
+        if UserDefaults.standard.object(forKey: Keys.checkForUpdatesOnLaunch) != nil {
+            self.checkForUpdatesOnLaunch = UserDefaults.standard.bool(forKey: Keys.checkForUpdatesOnLaunch)
+        } else {
+            self.checkForUpdatesOnLaunch = false
+        }
+
         // Onboarding completion defaults to false for new users
         if UserDefaults.standard.object(forKey: Keys.hasCompletedOnboarding) != nil {
             self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: Keys.hasCompletedOnboarding)
@@ -413,5 +441,7 @@ Now produce the complete meeting notes following the format above. Ensure every 
         indicatorPosition = .followCursor
         showLaunchConfirmation = true
         customVocabulary = []
+        checkForUpdatesOnLaunch = false
+        lastUpdateCheckDate = nil
     }
 }

--- a/Sources/LookMaNoHands/Services/UpdateService.swift
+++ b/Sources/LookMaNoHands/Services/UpdateService.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// Checks GitHub Releases for new versions and downloads updates
+class UpdateService {
+
+    // MARK: - Configuration
+
+    private let repoOwner = "qaid"
+    private let repoName = "look-ma-no-hands"
+    private let session = URLSession.shared
+
+    // MARK: - Types
+
+    struct UpdateInfo {
+        let version: String
+        let releaseNotes: String
+        let downloadURL: URL
+        let publishedAt: String
+    }
+
+    enum UpdateError: LocalizedError {
+        case invalidURL
+        case noReleaseFound
+        case noCompatibleAsset
+        case downloadFailed(String)
+        case networkError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Invalid GitHub API URL"
+            case .noReleaseFound:
+                return "No releases found"
+            case .noCompatibleAsset:
+                return "No DMG download found for this release"
+            case .downloadFailed(let reason):
+                return "Download failed: \(reason)"
+            case .networkError(let reason):
+                return "Network error: \(reason)"
+            }
+        }
+    }
+
+    // MARK: - GitHub API Response
+
+    private struct GitHubRelease: Codable {
+        let tagName: String
+        let name: String?
+        let body: String?
+        let publishedAt: String?
+        let assets: [Asset]
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case name
+            case body
+            case publishedAt = "published_at"
+            case assets
+        }
+
+        struct Asset: Codable {
+            let name: String
+            let browserDownloadUrl: String
+
+            enum CodingKeys: String, CodingKey {
+                case name
+                case browserDownloadUrl = "browser_download_url"
+            }
+        }
+    }
+
+    // MARK: - Semantic Version
+
+    struct SemanticVersion: Comparable {
+        let major: Int
+        let minor: Int
+        let patch: Int
+
+        static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+            if lhs.major != rhs.major { return lhs.major < rhs.major }
+            if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+            return lhs.patch < rhs.patch
+        }
+
+        /// Parse a version string like "1.0", "1.0.0", or "v1.0.0"
+        static func parse(_ string: String) -> SemanticVersion? {
+            let cleaned = string.hasPrefix("v") ? String(string.dropFirst()) : string
+            let parts = cleaned.split(separator: ".").compactMap { Int($0) }
+            guard parts.count >= 2 else { return nil }
+            return SemanticVersion(
+                major: parts[0],
+                minor: parts[1],
+                patch: parts.count >= 3 ? parts[2] : 0
+            )
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Get the current app version from the bundle
+    func getCurrentVersion() -> String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    /// Check GitHub for a newer release. Returns nil if up to date.
+    func checkForUpdates() async throws -> UpdateInfo? {
+        let urlString = "https://api.github.com/repos/\(repoOwner)/\(repoName)/releases/latest"
+        guard let url = URL(string: urlString) else {
+            throw UpdateError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw UpdateError.networkError(error.localizedDescription)
+        }
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            if httpResponse.statusCode == 404 {
+                throw UpdateError.noReleaseFound
+            }
+            throw UpdateError.networkError("HTTP \(httpResponse.statusCode)")
+        }
+
+        let decoder = JSONDecoder()
+        let release: GitHubRelease
+        do {
+            release = try decoder.decode(GitHubRelease.self, from: data)
+        } catch {
+            throw UpdateError.networkError("Failed to parse release: \(error.localizedDescription)")
+        }
+
+        // Compare versions
+        let currentVersion = getCurrentVersion()
+        guard let current = SemanticVersion.parse(currentVersion),
+              let latest = SemanticVersion.parse(release.tagName) else {
+            // Can't parse versions - treat as no update
+            return nil
+        }
+
+        guard latest > current else {
+            return nil // Up to date
+        }
+
+        // Find DMG asset
+        guard let dmgAsset = release.assets.first(where: { $0.name.hasSuffix(".dmg") }),
+              let downloadURL = URL(string: dmgAsset.browserDownloadUrl) else {
+            throw UpdateError.noCompatibleAsset
+        }
+
+        return UpdateInfo(
+            version: release.tagName.hasPrefix("v") ? String(release.tagName.dropFirst()) : release.tagName,
+            releaseNotes: release.body ?? "No release notes available.",
+            downloadURL: downloadURL,
+            publishedAt: release.publishedAt ?? ""
+        )
+    }
+
+    /// Download a DMG update to ~/Downloads and return the local file URL
+    func downloadUpdate(from url: URL) async throws -> URL {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(from: url)
+        } catch {
+            throw UpdateError.downloadFailed(error.localizedDescription)
+        }
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            throw UpdateError.downloadFailed("HTTP \(httpResponse.statusCode)")
+        }
+
+        let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+        let fileName = url.lastPathComponent
+        let destinationURL = downloadsURL.appendingPathComponent(fileName)
+
+        // Remove existing file if present
+        try? FileManager.default.removeItem(at: destinationURL)
+
+        do {
+            try data.write(to: destinationURL)
+        } catch {
+            throw UpdateError.downloadFailed("Could not save file: \(error.localizedDescription)")
+        }
+
+        return destinationURL
+    }
+}


### PR DESCRIPTION
## Summary

Implements privacy-respecting update checking for issue #78. The app checks GitHub Releases API on launch (when enabled, max once per day) and provides a manual "Check for Updates..." menu item. Auto-check is disabled by default; users must opt in via Settings toggle.

## Features

- New `UpdateService` with semantic version comparison and DMG download to ~/Downloads
- Silent startup check that sends notification if update available
- "Check for Updates..." menu item with update dialogs
- About tab shows dynamic version, update status, and auto-check toggle
- All network requests to public GitHub API only (no auth, no user data)

## Testing

- Build: `swift build -c release` ✓
- Menu bar shows "Check for Updates..." item
- Settings > About displays dynamic version and update UI
- Auto-check disabled by default, must be explicitly enabled

🤖 Generated with Claude Code