### PR TITLE
Add CLI tool preferences and search strategy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,186 @@ open ~/Applications/LookMaNoHands.app  # Launch production app
 - Wait for user confirmation before `git push`
 - Write clear commit messages matching existing style
 
+## Content Search Tool Policy
+
+**This project prefers ripgrep (rg) for content search** - faster, respects .gitignore, and matches all examples in this file.
+
+**Preference Order:**
+1. **FIRST CHOICE**: `Bash("rg 'pattern'")` - Use this when ripgrep is available
+2. **FALLBACK**: Grep tool - Use only if ripgrep unavailable or fails
+3. **AVOID**: bash `grep` commands - Slowest option, use rg or Grep tool instead
+
+**When Grep tool is acceptable:**
+- Ripgrep is not installed on the system (`which rg` returns empty)
+- The `rg` command fails with an error
+- Working in a different project without ripgrep
+- User's environment doesn't have rg available
+
+**Why prefer rg in this project:**
+- Faster than grep or Grep tool on large codebases
+- Respects .gitignore by default (cleaner results)
+- Project convention - all examples use rg
+- Better defaults for TypeScript/React codebases
+
+**Quick verification:**
+```bash
+which rg  # If this returns a path, prefer rg. If empty, use Grep tool.
+```
+
+## ALWAYS START WITH THESE COMMANDS FOR COMMON TASKS
+
+**Task: "List/summarize all files and directories"**
+
+```bash
+# PREFER (if available):
+fd . -t f           # Lists ALL files recursively (FASTEST)
+# OR
+rg --files          # Lists files (respects .gitignore)
+
+# FALLBACK (if fd/rg unavailable):
+# Use Glob tool with pattern **/*
+```
+
+**Task: "Search for content in files"**
+
+```bash
+# PREFER (if available):
+rg "search_term"    # Search everywhere (FASTEST, project standard)
+
+# FALLBACK (if rg unavailable):
+# Use Grep tool
+```
+
+**Task: "Find files by name"**
+
+```bash
+# PREFER (if available):
+fd "filename"       # Find by name pattern (FASTEST)
+
+# FALLBACK (if fd unavailable):
+# Use Glob tool with pattern **/filename*
+```
+
+### Directory/File Exploration
+
+```bash
+# PREFER - List all files/dirs recursively (if available):
+fd . -t f           # All files (fastest)
+fd . -t d           # All directories
+rg --files          # All files (respects .gitignore)
+
+# FALLBACK - If fd/rg unavailable:
+# Use Glob tool with appropriate patterns
+
+# For current directory only:
+ls -la              # OK for single directory view
+```
+
+### Tool Preference Order (This Project)
+
+**Content Search:**
+1. ✅ **FIRST CHOICE**: `Bash("rg 'pattern'")` - ripgrep (fastest, respects .gitignore, project convention)
+2. ✅ **FALLBACK**: Grep tool - only if rg unavailable or fails
+3. ❌ **AVOID**: bash `grep` or `grep -r` commands - slowest option
+
+**File Finding:**
+1. ✅ **FIRST CHOICE**: `Bash("fd 'pattern'")` - fd is faster
+2. ✅ **FALLBACK**: Glob tool - if fd unavailable
+3. ❌ **AVOID**: bash `find` command - slower
+
+**File Listing:**
+1. ✅ **FIRST CHOICE**: `Bash("rg --files")` or `Bash("fd . -t f")` - respects .gitignore
+2. ✅ **FALLBACK**: Glob tool with `**/*` pattern
+3. ❌ **NEVER**: `tree` - NOT INSTALLED on this system
+
+**Availability Check:**
+```bash
+which rg    # If returns path, use rg. If empty, use Grep tool.
+which fd    # If returns path, use fd. If empty, use Glob tool.
+```
+
+### Preferred Tools (When Available)
+
+**Use via Bash tool for optimal performance:**
+
+```bash
+# ripgrep (rg) - content search (PREFERRED in this project)
+Bash("rg 'search_term'")                # Search in all files
+Bash("rg -i 'case_insensitive'")        # Case-insensitive
+Bash("rg 'pattern' -t ts")              # Only TypeScript files
+Bash("rg 'pattern' -t tsx")             # Only TSX (React) files
+Bash("rg 'pattern' -g '*.md'")          # Only Markdown
+Bash("rg -l 'pattern'")                 # Filenames with matches
+Bash("rg -c 'pattern'")                 # Count matches per file
+Bash("rg -n 'pattern'")                 # Show line numbers
+Bash("rg -A 3 -B 3 'error'")            # Context lines
+Bash("rg '(TODO|FIXME|HACK)'")          # Multiple patterns
+
+# ripgrep (rg) - file listing
+Bash("rg --files")                      # List files (respects .gitignore)
+Bash("rg --files | rg 'pattern'")       # Find files by name
+Bash("rg --files -t md")                # Only Markdown files
+
+# fd - file finding (PREFERRED in this project)
+Bash("fd -e tsx")                       # All React component files
+Bash("fd -e ts")                        # All TypeScript files
+Bash("fd -x command {}")                # Exec per-file
+Bash("fd -e md -x ls -la {}")           # Example with ls
+
+# jq - JSON processing
+Bash("jq . data.json")                  # Pretty-print
+Bash("jq -r .name file.json")           # Extract field
+Bash("jq '.id = 0' x.json")             # Modify field
+```
+
+**Note:** If `rg` or `fd` are unavailable (check with `which rg` or `which fd`), fall back to Grep/Glob tools.
+
+### Search Strategy
+
+When using ripgrep (preferred):
+1. Start broad, then narrow: `Bash("rg 'partial' | rg 'specific'")`
+2. Filter by type early: `Bash("rg -t tsx 'export function'")` or `Bash("rg -t ts 'interface'")`
+3. Batch patterns: `Bash("rg '(pattern1|pattern2|pattern3)'")`
+4. Limit scope: `Bash("rg 'pattern' src/")` or `Bash("rg 'pattern' .planning/")`
+
+### Project-Specific Examples
+
+**Using ripgrep (preferred when available):**
+
+**Fallback (if rg/fd unavailable):**
+Use Grep tool with similar patterns or Glob tool for file finding.
+
+### INSTANT DECISION TREE
+
+```
+User asks to "list/show/summarize/explore files"?
+  → PREFER: Bash("fd . -t f")  (fastest, shows all files)
+  → OR: Bash("rg --files")  (respects .gitignore)
+  → FALLBACK: Glob tool if fd/rg unavailable
+
+User asks to "search/grep/find text content"?
+  → PREFER: Bash("rg 'pattern'")  (fastest, project standard)
+  → FALLBACK: Grep tool if rg unavailable or fails
+  → AVOID: bash grep command
+
+User asks to "find file/directory by name"?
+  → PREFER: Bash("fd 'name'")  (faster than find)
+  → FALLBACK: Glob tool if fd unavailable
+  → AVOID: bash find command
+
+User asks for "directory structure/tree"?
+  → PREFER: Bash("fd . -t d") for dirs + Bash("fd . -t f") for files
+  → NEVER: tree (not installed!)
+
+Need just current directory?
+  → USE: Bash("ls -la")  (OK for single dir)
+
+Unsure if tool is available?
+  → CHECK: Bash("which rg") or Bash("which fd")
+  → Use tool if returns path, use fallback if empty
+```
+
+
 ### Development Guidelines
 - **No Xcode**: Use Swift Package Manager + CLI tools only
 - **Privacy first**: All processing stays local on user's Mac


### PR DESCRIPTION
## Summary
- Adds a **Content Search Tool Policy** section documenting the preferred tool order: `rg` (ripgrep) over the Grep tool, `fd` over the Glob tool, with clear fallback guidance when CLI tools are unavailable.
- Includes usage examples for `rg`, `fd`, and `jq` covering common search, file-finding, and JSON processing tasks.
- Adds an **Instant Decision Tree** so the agent can quickly pick the right tool for file listing, content search, file finding, and directory exploration.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no existing sections were removed or altered unintentionally
- [ ] Spot-check that example commands are valid (`rg`, `fd`, `jq` flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)