### PR TITLE
Move media pause toggle to Recording tab (issue #93)

### DIFF
--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -311,6 +311,15 @@ struct SettingsView: View {
                 Text("Audio Input")
             }
 
+            Section {
+                Toggle("Pause media during dictation", isOn: $settings.pauseMediaDuringDictation)
+            } header: {
+                Text("Playback")
+            } footer: {
+                Text("Automatically pauses playing media when you start dictating and resumes it when you stop")
+                    .font(.caption)
+            }
+
             Spacer()
         }
     }
@@ -514,16 +523,6 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                 }
 
-                Divider()
-                    .padding(.vertical, 4)
-
-                // Media pause toggle
-                Toggle("Pause media during dictation", isOn: $settings.pauseMediaDuringDictation)
-                    .font(.body)
-
-                Text("Automatically pauses playing media when you start dictating and resumes it when you stop")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
             }
             .padding(20)
 


### PR DESCRIPTION
## Summary

Moved the "Pause media during dictation" toggle from the Models tab to the Recording tab under a new "Playback" section. This is a more intuitive location since media pause is a dictation behavior, not a model configuration.

## Test plan

- Open Settings and navigate to the Recording tab
- Verify the "Playback" section with the toggle is visible
- Toggle the setting on/off and verify it persists across app restarts
- Verify the Models tab no longer shows the media pause setting

Closes #93