### PR TITLE
Settings UI polish and media pause option

### DIFF
--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -144,7 +144,7 @@ struct SettingsView: View {
 
     private var generalTab: some View {
         Form {
-            // Appearance Section
+            // Position Section
             Section {
                 Toggle("Show recording indicator", isOn: $settings.showIndicator)
                     .help("Display a floating waveform visualizer while recording")
@@ -160,7 +160,7 @@ struct SettingsView: View {
                     .help("Choose where the waveform visualizer appears on screen")
                 }
             } header: {
-                Text("Appearance")
+                Text("Position")
                     .font(.headline)
             } footer: {
                 if settings.showIndicator {


### PR DESCRIPTION
## Summary

- **Auto-pause media setting (#93):** Add a toggle in Settings > Models > Dictation to let users control whether playing media pauses automatically during dictation. Includes the `MediaControlService` and `pauseMediaDuringDictation` setting, plus the `AppDelegate` integration to honor it.
- **Right margin fix (#96):** Increase trailing padding in the settings detail pane so text in Recording, General, and other tabs no longer crowds the right edge of the window.
- **General pane reorganization (#98):** Rename the "Appearance" section to "Position" so the three sections—Position, Startup, Advanced—have clear, equal hierarchy.

Also includes: macOS compatibility table in README (#92), version bump to 1.1.0, CLAUDE.md CLI tool preferences (#90), and media pause reliability fix (replaced unreliable MediaRemote with AppleScript-based `MediaControlService`).

Closes #93, closes #96, closes #98

## Test plan

- [ ] Open Settings > General and verify three sections: Position, Startup, Advanced
- [ ] Confirm text in all settings panes has adequate right margin
- [ ] Open Settings > Models > Dictation, toggle "Pause media during dictation" on/off
- [ ] Play music, invoke dictation—media should pause only when the toggle is on
- [ ] Verify the app builds cleanly with `swift build -c release`