### PR TITLE
Bump version to 1.1.1 and add Homebrew Cask support (issue #84)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,15 @@ jobs:
       - name: Build DMG
         run: ./scripts/create-dmg.sh "${{ steps.version.outputs.VERSION }}"
 
+      - name: Create ZIP archive
+        run: |
+          cd build
+          zip -r "LookMaNoHands-${{ steps.version.outputs.VERSION }}.zip" "Look Ma No Hands.app"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: "build/Look Ma No Hands ${{ steps.version.outputs.VERSION }}.dmg"
+          files: |
+            build/Look Ma No Hands ${{ steps.version.outputs.VERSION }}.dmg
+            build/LookMaNoHands-${{ steps.version.outputs.VERSION }}.zip
           generate_release_notes: true

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- Bump version from 1.1.0 to 1.1.1
- Update GitHub Actions workflow to create both DMG and ZIP archives
- ZIP archive enables Homebrew Cask distribution

## Changes
- Updated `CFBundleShortVersionString` to 1.1.1 in Info.plist
- Incremented `CFBundleVersion` to 4
- Modified `.github/workflows/release.yml` to generate ZIP archive alongside DMG