### PR TITLE
Fix media playback resuming unintentionally during dictation (resolves #114)

### DIFF
--- a/Sources/LookMaNoHands/Services/MediaControlService.swift
+++ b/Sources/LookMaNoHands/Services/MediaControlService.swift
@@ -9,10 +9,22 @@ class MediaControlService {
     private var didPauseMedia = false
 
     /// Pause system media playback before dictation recording begins.
+    /// Sends pause command multiple times to ensure it sticks (especially for browsers).
     func pauseMedia() {
         NSLog("⏸️ MediaControlService: pausing media")
-        sendMediaKey(down: true)
-        sendMediaKey(down: false)
+
+        // Send pause event multiple times to ensure browsers and other media players receive it
+        // Some apps (especially browsers) may need the event sent multiple times
+        for i in 0..<3 {
+            sendMediaKey(down: true)
+            sendMediaKey(down: false)
+
+            // Small delay between attempts (50ms)
+            if i < 2 {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+
         didPauseMedia = true
     }
 

--- a/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
@@ -49,8 +49,21 @@ class MixedAudioRecorder {
         micSamplesProcessed = 0
 
         // Start both recorders
-        try await systemAudioRecorder.startRecording()
-        try microphoneRecorder.startRecording()
+        // Note: microphoneRecorder.startRecording() will activate the audio session
+        // systemAudioRecorder uses ScreenCaptureKit and doesn't need session management
+        do {
+            try await systemAudioRecorder.startRecording()
+            try microphoneRecorder.startRecording()
+        } catch {
+            // Clean up if either fails
+            if systemAudioRecorder.isRecording {
+                _ = await systemAudioRecorder.stopRecording()
+            }
+            if microphoneRecorder.isRecording {
+                _ = microphoneRecorder.stopRecording()
+            }
+            throw error
+        }
 
         isRecording = true
 

--- a/Sources/LookMaNoHands/Services/MusicPlayerController.swift
+++ b/Sources/LookMaNoHands/Services/MusicPlayerController.swift
@@ -1,0 +1,154 @@
+import Foundation
+import AppKit
+
+/// Manages pause/resume of music players using AppleScript
+/// This is the macOS-specific approach to prevent media from resuming when recording starts
+final class MusicPlayerController {
+
+    // MARK: - Singleton
+
+    static let shared = MusicPlayerController()
+
+    // MARK: - Properties
+
+    /// Track which players were playing before we paused them
+    private var wasSpotifyPlaying = false
+    private var wasMusicPlaying = false
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Pause/Resume Control
+
+    /// Pause all supported music players and remember their state
+    /// Call this BEFORE starting AVAudioEngine to prevent media from resuming
+    func pauseAllPlayers() {
+        // Check and pause Spotify
+        wasSpotifyPlaying = isPlayerPlaying("Spotify")
+        if wasSpotifyPlaying {
+            pausePlayer("Spotify")
+            Logger.shared.info("Paused Spotify for dictation", category: .audio)
+        }
+
+        // Check and pause Apple Music
+        wasMusicPlaying = isPlayerPlaying("Music")
+        if wasMusicPlaying {
+            pausePlayer("Music")
+            Logger.shared.info("Paused Apple Music for dictation", category: .audio)
+        }
+
+        // Small delay to ensure AppleScript commands complete
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+
+    /// Resume players that were playing before pauseAllPlayers() was called
+    /// Call this AFTER stopping AVAudioEngine if you want to resume playback
+    func resumePreviouslyPlayingPlayers() {
+        if wasSpotifyPlaying {
+            resumePlayer("Spotify")
+            Logger.shared.info("Resumed Spotify after dictation", category: .audio)
+        }
+
+        if wasMusicPlaying {
+            resumePlayer("Music")
+            Logger.shared.info("Resumed Apple Music after dictation", category: .audio)
+        }
+
+        // Reset state
+        wasSpotifyPlaying = false
+        wasMusicPlaying = false
+    }
+
+    // MARK: - Private Methods
+
+    /// Check if a player is currently playing
+    private func isPlayerPlaying(_ appName: String) -> Bool {
+        // First check if app is actually running using NSWorkspace (no permission dialog)
+        let runningApps = NSWorkspace.shared.runningApplications
+        let isRunning = runningApps.contains { $0.localizedName == appName || $0.bundleIdentifier?.contains(appName.lowercased()) == true }
+
+        guard isRunning else {
+            // App not running, no need to check - this avoids permission dialogs
+            return false
+        }
+
+        let script = """
+        try
+            if application "\(appName)" is running then
+                tell application "\(appName)"
+                    return player state is playing
+                end tell
+            else
+                return false
+            end if
+        on error
+            return false
+        end try
+        """
+
+        if let scriptObject = NSAppleScript(source: script) {
+            var errorDict: NSDictionary?
+            let result = scriptObject.executeAndReturnError(&errorDict)
+
+            if let error = errorDict {
+                Logger.shared.debug("AppleScript error checking \(appName) state: \(error)", category: .audio)
+                return false
+            }
+
+            return result.booleanValue
+        }
+
+        return false
+    }
+
+    /// Pause a specific player using AppleScript
+    private func pausePlayer(_ appName: String) {
+        let script = """
+        try
+            if application "\(appName)" is running then
+                tell application "\(appName)"
+                    if player state is playing then
+                        pause
+                    end if
+                end tell
+            end if
+        on error errMsg
+            -- Silently fail if player doesn't support pause command
+        end try
+        """
+
+        executeAppleScript(script, description: "pause \(appName)")
+    }
+
+    /// Resume a specific player using AppleScript
+    private func resumePlayer(_ appName: String) {
+        let script = """
+        try
+            if application "\(appName)" is running then
+                tell application "\(appName)"
+                    if player state is paused then
+                        play
+                    end if
+                end tell
+            end if
+        on error errMsg
+            -- Silently fail if player doesn't support play command
+        end try
+        """
+
+        executeAppleScript(script, description: "resume \(appName)")
+    }
+
+    /// Execute an AppleScript and log errors
+    private func executeAppleScript(_ script: String, description: String) {
+        if let scriptObject = NSAppleScript(source: script) {
+            var errorDict: NSDictionary?
+            scriptObject.executeAndReturnError(&errorDict)
+
+            if let error = errorDict {
+                Logger.shared.debug("AppleScript error (\(description)): \(error)", category: .audio)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes issue where paused media (especially browser videos) would unexpectedly resume when dictation stopped, even though the user had manually paused the media before starting dictation.

## Root Cause
The original implementation used hardware play/pause toggle events that affected **all media** on the system. When dictation stopped, `mediaControlService.resumeMedia()` would send a blanket play/pause event that resumed:
- ✅ Music players that we paused (desired)
- ❌ Browser videos the user manually paused (undesired)

The hardware events couldn't distinguish between media we paused vs. media already paused by the user.

## Solution

### 1. MusicPlayerController (AppleScript-based state tracking)
- Created new `MusicPlayerController` service using AppleScript
- Controls Spotify and Apple Music directly via their scripting interfaces
- **Tracks state**: Only resumes players that were actually playing before dictation
- **Prevents permission dialogs**: Uses `NSWorkspace` to check if apps are running before attempting AppleScript access

### 2. Improved Pause Timing
- Changed pause timing: Now pauses **after** AVAudioEngine starts (not before)
- Sends pause commands **3 times** with 50ms delays to ensure browsers receive them
- 100ms delay after engine starts to let audio routing changes complete

### 3. Removed Blanket Resume
- Removed `mediaControlService.resumeMedia()` calls that were affecting all media
- Now only uses `MusicPlayerController.resumePreviouslyPlayingPlayers()`
- Browser media stays paused as expected ✓

### 4. Better Error Handling
- Improved `MixedAudioRecorder` to properly clean up if either recorder fails
- More descriptive error messages for audio configuration failures

## Testing
- ✅ Browser media (YouTube, etc.) that user paused manually stays paused after dictation
- ✅ Spotify/Apple Music that were playing resume after dictation (if installed)
- ✅ No permission dialogs for apps that aren't installed
- ✅ Multiple pause events ensure browsers receive commands even during audio routing changes

## Files Changed
- **New**: `MusicPlayerController.swift` - AppleScript-based music player control with state tracking
- **Modified**: `AppDelegate.swift` - Integrated MusicPlayerController, changed pause timing
- **Modified**: `MediaControlService.swift` - Added multiple pause events with delays
- **Modified**: `MixedAudioRecorder.swift` - Improved error handling

Resolves #114