### PR TITLE
Fix meeting transcription segment overwrite across multiple sessions

### DIFF
--- a/Sources/LookMaNoHands/Views/MeetingView.swift
+++ b/Sources/LookMaNoHands/Views/MeetingView.swift
@@ -1042,8 +1042,9 @@ struct MeetingView: View {
         let finalSegments = await continuousTranscriber.endSession()
 
         // Create recording session
-        let sessionStartIndex = meetingState.segments.count
-        let sessionEndIndex = finalSegments.count
+        // Calculate correct indices: segments are already added via callback
+        let sessionStartIndex = meetingState.segments.count - finalSegments.count
+        let sessionEndIndex = meetingState.segments.count
 
         // Only create session if we have new segments
         if sessionEndIndex > sessionStartIndex {
@@ -1055,12 +1056,12 @@ struct MeetingView: View {
             meetingState.recordingSessions.append(newSession)
         }
 
-        // Update with all segments
-        meetingState.segments = finalSegments
+        // Segments are already in meetingState.segments via real-time callback
+        // (no need to overwrite - that would lose previous sessions' segments)
 
         meetingState.isRecording = false
         meetingState.status = .completed
-        meetingState.statusMessage = "Recording stopped - \(finalSegments.count) segments"
+        meetingState.statusMessage = "Recording stopped - \(meetingState.segments.count) segments total"
 
         // Notify AppDelegate that recording stopped
         appDelegate?.isMeetingRecording = false


### PR DESCRIPTION
## Summary

Fixes #129 - Meeting transcription now correctly preserves segments from all recording sessions instead of overwriting them.

## Problem

When using Meeting Transcription mode with multiple recording sessions (start → stop → start → stop), transcript segments from previous recording sessions were being overwritten and lost. Only the segments from the most recent recording session were preserved.

## Root Cause

The bug was in `MeetingView.swift:1059` in the `stopRecording()` method:

**Before:**
```swift
// Segments added in real-time via callback
continuousTranscriber.onSegmentTranscribed = { segment in
    meetingState.segments.append(segment)
}

// Later in stopRecording():
let finalSegments = await continuousTranscriber.endSession()  // Only current session
meetingState.segments = finalSegments  // ❌ OVERWRITES all segments!
```

The issue: segments are added in real-time via the callback, but then `stopRecording()` overwrites ALL segments with only the current session's segments returned by `endSession()`.

## Solution

**Changes made:**

1. **Fixed segment range calculation** - Now correctly calculates indices for the current session:
   ```swift
   let sessionStartIndex = meetingState.segments.count - finalSegments.count
   let sessionEndIndex = meetingState.segments.count
   ```

2. **Removed the overwrite** - Segments are already in `meetingState.segments` via the real-time callback, no need to overwrite

3. **Updated status message** - Now shows total segment count across all sessions

**After:**
```swift
// Segments already added via callback - just track the range
let sessionStartIndex = meetingState.segments.count - finalSegments.count
let sessionEndIndex = meetingState.segments.count
// No overwrite! Segments persist across sessions ✅
```

## Testing

✅ Build completes successfully  
✅ Multiple recording sessions now preserve all segments  
✅ Recording session bars correctly highlight their segment ranges  
✅ Status message shows total count: "Recording stopped - X segments total"

### Manual Testing Steps

1. Open Meeting Transcription mode
2. Start recording, speak some words, stop recording
3. Verify segments appear
4. Start recording again (second session), speak different words, stop
5. **Verify**: Both sets of segments are visible (previously only second session would show)
6. Click recording session bars to verify correct segment highlighting

## Impact

- **Before**: Users lost all previous transcript data when starting a new recording session
- **After**: All transcript segments persist across multiple sessions as expected
- **Breaking Changes**: None - this is a pure bug fix

## Files Changed

- `Sources/LookMaNoHands/Views/MeetingView.swift` (6 insertions, 5 deletions)