### PR TITLE
Fix: Prevent Music app launch on clean install when dictation triggers

### DIFF
--- a/Sources/LookMaNoHands/Services/MediaControlService.swift
+++ b/Sources/LookMaNoHands/Services/MediaControlService.swift
@@ -3,9 +3,10 @@ import Cocoa
 /// Controls system media playback using macOS MediaRemote framework.
 /// Used to auto-pause media when dictation starts and resume when it ends.
 ///
-/// Uses MRMediaRemoteSendCommand to send explicit pause/play commands instead
-/// of hardware play/pause toggle events (NX_KEYTYPE_PLAY), which would launch
-/// Apple Music if no media app is currently the "Now Playing" source. (#128)
+/// Before sending any command, checks whether media is actually playing.
+/// Without this guard, sending commands when no app owns the "Now Playing"
+/// session (e.g. on a clean install) causes macOS to launch Apple Music
+/// as the default media handler. (#128)
 class MediaControlService {
 
     /// Whether we paused media (so we only resume what we paused)
@@ -14,36 +15,44 @@ class MediaControlService {
     /// Cached function pointer for MRMediaRemoteSendCommand
     private var sendCommandFunc: MRMediaRemoteSendCommandFunc?
 
+    /// Cached function pointer for MRMediaRemoteGetNowPlayingApplicationIsPlaying
+    private var getNowPlayingIsPlayingFunc: MRMediaRemoteGetNowPlayingIsPlayingFunc?
+
     /// Whether MediaRemote framework loaded successfully
     private var mediaRemoteAvailable = false
 
-    // MediaRemote function type: MRMediaRemoteSendCommand(command, options) -> Bool
+    // MediaRemote function types
     private typealias MRMediaRemoteSendCommandFunc = @convention(c) (UInt32, CFDictionary?) -> Bool
+    private typealias MRMediaRemoteGetNowPlayingIsPlayingFunc = @convention(c) (DispatchQueue, @escaping (Bool) -> Void) -> Void
 
     // MediaRemote command constants
     private static let kMRPlay: UInt32 = 0
     private static let kMRPause: UInt32 = 1
-    private static let kMRTogglePlayPause: UInt32 = 2
 
     init() {
         loadMediaRemote()
     }
 
     /// Pause system media playback before dictation recording begins.
-    /// Sends an explicit pause command (not a toggle) so it won't start playback
-    /// if nothing is currently playing.
+    /// Only sends the pause command if something is actually playing,
+    /// preventing Apple Music from launching on a clean install. (#128)
     func pauseMedia() {
-        if mediaRemoteAvailable, let sendCommand = sendCommandFunc {
-            NSLog("⏸️ MediaControlService: sending pause command via MediaRemote")
-            _ = sendCommand(Self.kMRPause, nil)
-            didPauseMedia = true
-        } else {
-            // Fallback: use hardware media key event if MediaRemote unavailable
-            NSLog("⏸️ MediaControlService: MediaRemote unavailable, using hardware key fallback")
-            sendMediaKey(down: true)
-            sendMediaKey(down: false)
-            didPauseMedia = true
+        guard mediaRemoteAvailable, let sendCommand = sendCommandFunc else {
+            NSLog("⏸️ MediaControlService: MediaRemote unavailable, skipping pause")
+            return
         }
+
+        // Check if anything is actually playing before sending pause.
+        // Sending commands when nothing is playing causes macOS to launch
+        // Apple Music as the default media handler on clean installs.
+        guard isNowPlayingActive() else {
+            NSLog("⏸️ MediaControlService: nothing currently playing, skipping pause to avoid launching Music")
+            return
+        }
+
+        NSLog("⏸️ MediaControlService: sending pause command via MediaRemote")
+        _ = sendCommand(Self.kMRPause, nil)
+        didPauseMedia = true
     }
 
     /// Resume system media playback after dictation ends, but only if we paused it.
@@ -54,9 +63,7 @@ class MediaControlService {
             NSLog("▶️ MediaControlService: sending play command via MediaRemote")
             _ = sendCommand(Self.kMRPlay, nil)
         } else {
-            NSLog("▶️ MediaControlService: MediaRemote unavailable, using hardware key fallback")
-            sendMediaKey(down: true)
-            sendMediaKey(down: false)
+            NSLog("▶️ MediaControlService: MediaRemote unavailable, cannot resume")
         }
 
         didPauseMedia = false
@@ -72,40 +79,63 @@ class MediaControlService {
             return
         }
 
-        guard let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteSendCommand" as CFString) else {
+        guard let sendPtr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteSendCommand" as CFString) else {
             NSLog("⚠️ MediaControlService: Could not find MRMediaRemoteSendCommand")
             return
         }
 
-        sendCommandFunc = unsafeBitCast(ptr, to: MRMediaRemoteSendCommandFunc.self)
+        sendCommandFunc = unsafeBitCast(sendPtr, to: MRMediaRemoteSendCommandFunc.self)
         mediaRemoteAvailable = true
-        NSLog("✅ MediaControlService: MediaRemote framework loaded successfully")
+
+        // Also load the "is playing" check to gate commands
+        if let isPlayingPtr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying" as CFString) {
+            getNowPlayingIsPlayingFunc = unsafeBitCast(isPlayingPtr, to: MRMediaRemoteGetNowPlayingIsPlayingFunc.self)
+            NSLog("✅ MediaControlService: MediaRemote framework loaded (with Now Playing check)")
+        } else {
+            NSLog("✅ MediaControlService: MediaRemote framework loaded (without Now Playing check, using app-list fallback)")
+        }
     }
 
-    /// Fallback: Simulate a hardware play/pause media key press via CGEvent.
-    /// Only used if MediaRemote framework is unavailable.
-    private func sendMediaKey(down: Bool) {
-        // NX_KEYTYPE_PLAY = 16, NX_SUBTYPE_AUX_CONTROL_BUTTONS = 8
-        let keyType: UInt32 = 16
-        let flags: UInt32 = down ? 0xA : 0xB
-        let data1 = Int((keyType << 16) | (flags << 8))
+    /// Check if any media is currently playing before sending commands.
+    /// Returns false on a clean install (no Now Playing source), which
+    /// prevents the pause command from inadvertently launching Music.
+    private func isNowPlayingActive() -> Bool {
+        // Primary: use MediaRemote async API to check actual playback state
+        if let getNowPlayingIsPlaying = getNowPlayingIsPlayingFunc {
+            let semaphore = DispatchSemaphore(value: 0)
+            var isPlaying = false
 
-        let event = NSEvent.otherEvent(
-            with: .systemDefined,
-            location: .zero,
-            modifierFlags: NSEvent.ModifierFlags(rawValue: 0xa00),
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            subtype: 8,
-            data1: data1,
-            data2: -1
-        )
+            getNowPlayingIsPlaying(DispatchQueue.global(qos: .userInteractive)) { playing in
+                isPlaying = playing
+                semaphore.signal()
+            }
 
-        if let cgEvent = event?.cgEvent {
-            cgEvent.post(tap: .cghidEventTap)
-        } else {
-            NSLog("⚠️ MediaControlService: failed to create CGEvent for media key")
+            let result = semaphore.wait(timeout: .now() + 0.1)
+            if result == .success {
+                return isPlaying
+            }
+            NSLog("⚠️ MediaControlService: Now Playing check timed out, falling back to app check")
+        }
+
+        // Fallback: check if any known media app is running
+        return isAnyMediaAppRunning()
+    }
+
+    /// Fallback heuristic: check if any common dedicated media app is running.
+    /// On a clean install none of these will be running, correctly returning false.
+    private func isAnyMediaAppRunning() -> Bool {
+        let mediaAppBundleIDs: Set<String> = [
+            "com.apple.Music",
+            "com.apple.TV",
+            "com.spotify.client",
+            "org.videolan.vlc",
+            "com.coppertino.Vox",
+            "com.plexapp.plexamp",
+        ]
+
+        return NSWorkspace.shared.runningApplications.contains { app in
+            guard let bundleID = app.bundleIdentifier else { return false }
+            return mediaAppBundleIDs.contains(bundleID)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Guards all MediaRemote commands with a "Now Playing" check** — before sending `kMRPause` or `kMRPlay`, queries `MRMediaRemoteGetNowPlayingApplicationIsPlaying` to confirm media is actually active. On a clean install (no Now Playing source), this returns `false` and the command is skipped entirely, preventing macOS from routing it to Apple Music.
- **Removes the unsafe hardware-key fallback** — the old `sendMediaKey()` path sent `NX_KEYTYPE_PLAY` (a play/pause *toggle*), which launched and started Music when no app was the Now Playing source. This fallback is now gone; if MediaRemote is unavailable the service safely no-ops.
- **Adds a running-apps heuristic fallback** — if the `MRMediaRemoteGetNowPlayingApplicationIsPlaying` API is unavailable or times out (100ms), falls back to checking `NSWorkspace.shared.runningApplications` for known media app bundle IDs. On a clean install none are running, so this also correctly returns `false`.

### Root Cause

`MediaControlService.pauseMedia()` sent `MRMediaRemoteSendCommand(kMRPause)` unconditionally. When no app owned the "Now Playing" session (clean install), macOS routed the command to Apple Music as the default media handler, launching it. The previous fix (#138) switched from hardware toggle keys to explicit pause commands, but didn't account for the case where *no* Now Playing source exists at all.

## Test plan

- [ ] Clean install (or Developer Reset): trigger dictation hotkey → Apple Music should NOT launch
- [ ] With Spotify/Music playing: trigger dictation → media should pause, resume after dictation completes
- [ ] With no media apps running: trigger dictation → no media-related side effects
- [ ] Check Console.app logs for `MediaControlService` messages confirming the guard works