### PR TITLE
Fix context-aware dictation formatting and cursor positioning

### DIFF
--- a/Sources/LookMaNoHands/Services/TextFormatter.swift
+++ b/Sources/LookMaNoHands/Services/TextFormatter.swift
@@ -7,10 +7,12 @@ class TextFormatter {
     // MARK: - Configuration
 
     /// Whether to enable smart capitalization
-    var smartCapitalization = true
+    /// NOTE: This should stay FALSE for dictation - TextInsertionService handles capitalization context-aware
+    var smartCapitalization = false
 
     /// Whether to add punctuation at the end if missing
-    var addFinalPunctuation = true
+    /// NOTE: This should stay FALSE for dictation - TextInsertionService handles punctuation context-aware
+    var addFinalPunctuation = false
 
     /// Whether to fix common transcription errors
     var fixCommonErrors = true
@@ -209,14 +211,14 @@ extension TextFormatter {
                 formatter.trimWhitespace = true
 
             case .standard:
-                formatter.smartCapitalization = true
-                formatter.addFinalPunctuation = true
+                formatter.smartCapitalization = false  // Context-aware in TextInsertionService
+                formatter.addFinalPunctuation = false  // Context-aware in TextInsertionService
                 formatter.fixCommonErrors = true
                 formatter.trimWhitespace = true
 
             case .maximum:
-                formatter.smartCapitalization = true
-                formatter.addFinalPunctuation = true
+                formatter.smartCapitalization = false  // Context-aware in TextInsertionService
+                formatter.addFinalPunctuation = false  // Context-aware in TextInsertionService
                 formatter.fixCommonErrors = true
                 formatter.trimWhitespace = true
             }


### PR DESCRIPTION
## Summary

- **Fixed premature formatting**: TextFormatter was adding periods and capitalizing text before TextInsertionService could analyze cursor context, causing wrong punctuation/capitalization when dictating mid-sentence
- **Fixed cursor jumping to beginning**: Switched from AX `kAXValueAttribute` (replaces entire field, resets cursor) to clipboard paste as primary insertion method, which preserves native cursor positioning
- **Preserved context-aware formatting**: AX API still used for reading surrounding text context to determine correct capitalization, punctuation, and spacing

## What was fixed

### Context-aware formatting
TextFormatter's `smartCapitalization` and `addFinalPunctuation` are now disabled by default. These responsibilities moved to TextInsertionService which has cursor context and can make correct decisions:
- No period added when cursor is mid-sentence
- Lowercase first letter when continuing a sentence
- Proper leading/trailing space based on adjacent characters

### Cursor positioning
Previously used `kAXValueAttribute` to replace the entire text field content, causing apps to reset cursor to position 0. Now uses clipboard Cmd+V paste as the primary insertion method, which natively inserts at cursor and leaves cursor at end of pasted text. AX API retained as fallback with progressive retry logic.

## Test plan

- [ ] Dictate with cursor at end of text field — period added, capitalized
- [ ] Dictate with cursor mid-sentence — no period, lowercase, proper spacing
- [ ] Dictate with cursor at beginning — capitalized, trailing space added
- [ ] Dictate into empty field — capitalized with period
- [ ] Verify cursor remains at end of inserted text in all positions
- [ ] Test in multiple apps (Notes, TextEdit, browser text fields)