### PR TITLE
Add restart button after granting accessibility permission (#145)

### DIFF
--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -60,6 +60,7 @@ struct SettingsView: View {
     @State private var permissionsChanged = false
     @State private var previousMicPermission: PermissionState = .unknown
     @State private var previousAccessibilityPermission: PermissionState = .unknown
+    @State private var shouldShowAccessibilityRestartBanner = false
 
     var body: some View {
         NavigationSplitView {
@@ -699,6 +700,11 @@ struct SettingsView: View {
 
     private var permissionsTab: some View {
         VStack(alignment: .leading, spacing: 20) {
+            // Restart banner when accessibility permission is granted
+            if shouldShowAccessibilityRestartBanner {
+                restartBanner
+            }
+
             // Microphone
             permissionRow(
                 title: "Microphone",
@@ -1202,6 +1208,48 @@ struct SettingsView: View {
                 .font(.caption)
         }
     }
+
+    /// Restart banner shown when accessibility permission is granted
+    private var restartBanner: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.green)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Accessibility Permission Granted")
+                        .font(.headline)
+                        .fontWeight(.semibold)
+
+                    Text("The app needs to restart to recognize the new permission and enable dictation.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Button {
+                    restartApp()
+                } label: {
+                    Text("Restart to Enable Dictation")
+                        .fontWeight(.medium)
+                }
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.accentColor.opacity(0.1))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.accentColor.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
     
     private func connectionStatusView(_ state: ConnectionState, label: String) -> some View {
         HStack(spacing: 4) {
@@ -1242,6 +1290,11 @@ struct SettingsView: View {
         if previousMicPermission != .unknown || previousAccessibilityPermission != .unknown {
             if newMicPermission != previousMicPermission || newAccessibilityPermission != previousAccessibilityPermission {
                 permissionsChanged = true
+            }
+
+            // Specifically track when accessibility permission changes from not-granted to granted
+            if previousAccessibilityPermission != .granted && newAccessibilityPermission == .granted {
+                shouldShowAccessibilityRestartBanner = true
             }
         }
 


### PR DESCRIPTION
## Summary

Resolves #145 

Adds a prominent restart button in Settings that appears when users grant Accessibility permission in System Settings. This fixes the critical UX issue where the app doesn't recognize newly granted permissions until manually restarted.

## Changes

**Visual Enhancement:**
- Prominent banner at top of Permissions tab when accessibility permission is granted
- Green checkmark icon with clear "Accessibility Permission Granted" heading
- Explanatory text about why restart is needed
- Large, accent-colored "Restart to Enable Dictation" button

**Smart Detection:**
- New `shouldShowAccessibilityRestartBanner` state flag
- Triggers only when accessibility permission transitions from denied/unknown → granted
- Leverages existing 1-second permission polling on Permissions tab
- Won't trigger for other permission changes (microphone, screen recording)
- Banner automatically disappears after restart

**One-Click Restart:**
- Button calls existing `restartApp()` function
- Uses `NSWorkspace.openApplication()` to launch new instance
- Gracefully terminates current instance
- Dictation works immediately after restart

## Implementation Details

**File Modified:** `Sources/LookMaNoHands/Views/SettingsView.swift` (+53 lines)
- Added `shouldShowAccessibilityRestartBanner` state variable
- Enhanced `checkPermissions()` to detect accessibility permission transition
- Created `restartBanner` computed view with accent styling
- Integrated banner into `permissionsTab`

## Testing

**Tested scenarios:**
- ✅ Fresh permission grant → banner appears
- ✅ Already granted → no banner
- ✅ Multiple tab switches → banner persists correctly
- ✅ Other permission changes → no banner
- ✅ After restart → banner doesn't reappear

## Screenshots

The banner appears prominently at the top of the Permissions tab:
- Green checkmark icon signals success
- Clear explanation of why restart is needed
- One-click "Restart to Enable Dictation" button
- Accent color styling for visual prominence

## Acceptance Criteria

All requirements from #145 met:
- ✅ Restart button appears after permission granted
- ✅ Visually prominent (accent color, large size)
- ✅ Clear label explaining restart reason
- ✅ One-click restart works correctly
- ✅ Dictation works immediately after restart
- ✅ Button only shows when recently granted
- ✅ Handles edge case: no banner if already restarted

## Priority

**High** - Addresses critical first-time setup UX issue that makes app appear broken