### PR TITLE
Fix hotkey trigger and WhisperKit model loading

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -237,7 +237,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             switch url.host {
             case "toggle":
                 NSLog("📞 URL command: toggle recording")
-                handleTriggerKey()
+                startOrStopRecording()
             case "start":
                 NSLog("📞 URL command: start recording")
                 if !transcriptionState.isRecording && transcriptionState.recordingState == .idle {
@@ -354,7 +354,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc private func toggleRecording() {
-        handleTriggerKey()
+        startOrStopRecording()
     }
 
     @objc private func toggleHotkeyEnabled() {
@@ -679,7 +679,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
               hotkey.isSingleModifierKey ? "YES" : "NO")
 
         let success = keyboardMonitor.startMonitoring(hotkey: hotkey) { [weak self] in
-            self?.handleTriggerKey()
+            self?.handleHotkeyTrigger()
         }
 
         // Set up ESC key cancellation callback
@@ -696,7 +696,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSLog("🔄 Retrying keyboard monitoring setup...")
                 let retryHotkey = Settings.shared.effectiveHotkey
                 if self?.keyboardMonitor.startMonitoring(hotkey: retryHotkey, onTrigger: { [weak self] in
-                    self?.handleTriggerKey()
+                    self?.handleHotkeyTrigger()
                 }) == true {
                     NSLog("✅ Keyboard monitoring started on retry for %@", retryHotkey.displayString)
                 }
@@ -806,14 +806,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Recording Workflow
 
-    /// Handle Caps Lock key press - toggles recording
-    private func handleTriggerKey() {
+    /// Handle hotkey press (Caps Lock, etc.) - toggles recording
+    /// This method respects the hotkeyEnabled setting
+    private func handleHotkeyTrigger() {
         guard Settings.shared.hotkeyEnabled else {
             NSLog("⚠️ Hotkey disabled - ignoring trigger")
             return
         }
 
-        print("handleTriggerKey called, current state: \(transcriptionState.recordingState)")
+        startOrStopRecording()
+    }
+
+    /// Start or stop recording (used by menu bar, URL scheme, and hotkey)
+    /// This method bypasses the hotkeyEnabled check - it's for manual user actions
+    private func startOrStopRecording() {
+        print("startOrStopRecording called, current state: \(transcriptionState.recordingState)")
 
         if transcriptionState.isRecording {
             print("Stopping recording...")

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -1457,8 +1457,7 @@ struct SettingsView: View {
     /// Check availability of all Whisper models
     private func checkWhisperModelStatus() {
         for model in WhisperModel.allCases {
-            let exists = WhisperService.modelExists(named: model.rawValue)
-            modelAvailability[model] = exists
+            modelAvailability[model] = WhisperService.modelExists(named: model.rawValue)
         }
     }
 
@@ -1467,17 +1466,10 @@ struct SettingsView: View {
         // Clear any previous error
         modelDownloadError = nil
 
-        // Check if model exists
-        let modelExists = WhisperService.modelExists(named: newModel.rawValue)
-
-        if !modelExists {
-            // Model doesn't exist, start download
+        if !WhisperService.modelExists(named: newModel.rawValue) {
             Task {
                 await downloadModel(newModel)
             }
-        } else {
-            print("SettingsView: Model \(newModel.rawValue) already downloaded")
-            // TODO: Notify AppDelegate to reload the model if needed
         }
     }
 


### PR DESCRIPTION
## Summary
- Refactor hotkey trigger handling with separate methods for hotkey-gated and manual actions
- Fix WhisperKit cache directory configuration to avoid Documents folder permission prompts
- Add retry logic for corrupted model downloads during initialization
- Improve error display in onboarding view for download failures
- Simplify model availability checking in settings view

## Test Plan
- [ ] Press Caps Lock to verify recording starts/stops correctly
- [ ] Verify hotkey works globally across different apps
- [ ] Test onboarding model download flow
- [ ] Confirm error messages display correctly if download fails
- [ ] Check that model selection in Settings works as expected