### PR TITLE
Improve model loading UX with warm-up and status tracking

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -40,6 +40,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let updateService = UpdateService()
     private let mediaControlService = MediaControlService()
 
+    /// Exposed for SettingsView to check model status
+    var whisperServiceForSettings: WhisperService { whisperService }
+
     // UI
     private let recordingIndicator = RecordingIndicatorWindowController()
     private let launchSplash = LaunchSplashWindowController()
@@ -403,7 +406,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.delegate = self
 
         // Create SwiftUI settings view and wrap it in NSHostingView
-        let settingsView = SettingsView()
+        let settingsView = SettingsView(whisperService: whisperService)
         let hostingView = NSHostingView(rootView: settingsView)
         window.contentView = hostingView
 
@@ -1036,8 +1039,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         transcriptionState.stopRecording()
         updateMenuBarIcon(isRecording: false)
 
-        // Hide indicator immediately to avoid frozen waveform
-        // (waveform stops animating when isRecording = false)
+        // DESIGN: No processing indicator is shown after recording stops.
+        // Hide the recording indicator immediately and process in the background.
+        // The transcribed text appears directly - no spinner, shimmer, or progress bar.
+        // This makes dictation feel instant. The Neural Engine warm-up happens during onboarding.
         recordingIndicator.hide()
 
         // Resume system media if we paused it

--- a/Sources/LookMaNoHands/App/LookMaNoHandsApp.swift
+++ b/Sources/LookMaNoHands/App/LookMaNoHandsApp.swift
@@ -11,7 +11,7 @@ struct LookMaNoHandsApp: App {
     var body: some Scene {
         // Settings window - opened from menu bar
         SwiftUI.Settings {
-            SettingsView()
+            SettingsView(whisperService: appDelegate.whisperServiceForSettings)
         }
     }
 }

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -19,6 +19,9 @@ class WhisperService: @unchecked Sendable {
 
     /// Whether model is currently loading
     private(set) var isModelLoading = false
+
+    /// Name of the currently loaded model (e.g., "base", "large-v3-turbo")
+    private(set) var loadedModelName: String?
     
     // MARK: - Initialization
 
@@ -26,7 +29,10 @@ class WhisperService: @unchecked Sendable {
     /// - Parameter modelName: Name of the model (e.g., "base", "small", "tiny", "large-v3-turbo")
     func loadModel(named modelName: String = "base") async throws {
         isModelLoading = true
-        defer { isModelLoading = false }
+        defer {
+            isModelLoading = false
+            if isModelLoaded { loadedModelName = modelName }
+        }
 
         Logger.shared.info("Loading WhisperKit model '\(modelName)'...", category: .whisper)
 

--- a/Sources/LookMaNoHands/Views/OnboardingView.swift
+++ b/Sources/LookMaNoHands/Views/OnboardingView.swift
@@ -461,6 +461,12 @@ struct WhisperModelStepView: View {
                 // loadModel() downloads if needed and keeps the WhisperKit instance ready
                 try await whisperService.loadModel(named: modelName)
 
+                // Warm up the Neural Engine with a short silent transcription.
+                // This runs while the download progress UI is still visible, so the user
+                // just sees a slightly longer "download" time. Prevents slow first dictation.
+                let silentSamples = [Float](repeating: 0.0, count: 16000)
+                _ = try? await whisperService.transcribe(samples: silentSamples)
+
                 await MainActor.run {
                     onboardingState.isDownloadingModel = false
                     onboardingState.modelDownloaded = true


### PR DESCRIPTION
## Summary

- Add WhisperService reference to SettingsView for checking loaded model status
- Warm up Neural Engine during onboarding with silent transcription run
- Track the loaded model name in WhisperService
- Improve model download logic to check if model is already loaded
- Add design documentation for instant dictation feedback

## Testing

- Verify onboarding completes successfully with Neural Engine warm-up
- Check that settings view properly displays loaded model status
- Confirm model download logic respects already-loaded models
- Test that first dictation after onboarding feels instant