### PR TITLE
Fix permission dialogs shown before onboarding (issue #164)

### DIFF
--- a/Sources/LookMaNoHands/Views/MeetingView.swift
+++ b/Sources/LookMaNoHands/Views/MeetingView.swift
@@ -828,8 +828,11 @@ struct MeetingView: View {
             return
         }
 
-        // Check permissions
-        // TODO: Add permission checks
+        // Check screen recording permission
+        if !SystemAudioRecorder.hasPermission() {
+            meetingState.status = .missingPermissions
+            return
+        }
 
         meetingState.status = .ready
     }
@@ -1019,6 +1022,16 @@ struct MeetingView: View {
 
     private func startRecording() async {
         do {
+            // Request screen recording permission if not yet determined
+            if !SystemAudioRecorder.hasPermission() {
+                let granted = await SystemAudioRecorder.requestPermission()
+                if !granted {
+                    meetingState.status = .missingPermissions
+                    meetingState.statusMessage = "Screen recording permission required"
+                    return
+                }
+            }
+
             // Set session start date on first recording
             if meetingState.sessionStartDate == nil {
                 meetingState.sessionStartDate = Date()


### PR DESCRIPTION
## Summary
This PR fixes the poor first-launch experience where system permission dialogs (microphone, accessibility, screen recording) appeared before users saw the onboarding screens that explain what these permissions are needed for.

## Changes
- **Removed proactive permission checking** from app initialization (`completeInitialization()`)
- **Implemented lazy permission checking** that only requests permissions when features are actually used
- **Added microphone permission check** to dictation feature (`startRecording()` in AppDelegate)
- **Added screen recording permission check** to meeting mode (MeetingView)

## Testing
After removing permissions from System Settings, users should see:
1. App launches without permission dialogs
2. Onboarding displays with permissions marked as not granted
3. System permission dialogs only appear when user explicitly uses features (Caps Lock for dictation, Start Recording for meetings)
4. No additional dialogs after onboarding completes

Fixes #164