### PR TITLE
Restore cursor focus when ESC cancels recording (issue #153)

### DIFF
--- a/Sources/LookMaNoHands/Services/TextInsertionService.swift
+++ b/Sources/LookMaNoHands/Services/TextInsertionService.swift
@@ -110,7 +110,7 @@ class TextInsertionService {
     }
     
     /// Get the currently focused accessibility element
-    private func getFocusedElement() -> AXUIElement? {
+    func getFocusedElement() -> AXUIElement? {
         // Get the system-wide accessibility element
         let systemWide = AXUIElementCreateSystemWide()
         


### PR DESCRIPTION
## Summary
- Captures the focused accessibility element when recording starts
- Restores focus to the original field if the user cancels with ESC
- Clears stored focus reference after successful transcription completion

## Test Plan
- [ ] Start recording, then press ESC to cancel - cursor should return to original field
- [ ] Ensure focus restoration works in different applications (browsers, editors, etc.)
- [ ] Complete a recording successfully - focus should update to new field where text was inserted