### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- Updates version from 1.1.1 to **1.2.0** (minor release)
- Increments build number from 4 to 5

## New Features Since 1.1.1
- ⚡ **Migrate to WhisperKit** for 2.7x faster transcription on Apple Silicon (#154)
- 🔋 **75% lower energy consumption** with native Neural Engine support
- 🎯 **Add large-v3-turbo model** option for improved meeting transcription accuracy
- 🔄 **Native streaming support** with modernized async/await API
- 📦 **Simplified model management** via Hugging Face integration

## Bug Fixes
- ✅ Restore cursor focus when recording canceled with ESC (#166)
- ✅ Fix permission dialogs shown before onboarding (#165)
- ✅ Persist toggle hotkey across app reinstalls (#163)
- ✅ Fix Neural Engine warmup and permission dialogs (#162)
- ✅ Fix model status incorrectly showing as 'Not Downloaded' (#159)
- ✅ Fix dictation trigger and improve WhisperKit model loading (#158)

## Next Steps
After merging, create a GitHub release with tag `v1.2.0`