### PR TITLE
Optimize security workflows with path filtering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,18 @@ name: "CodeQL Advanced Security"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   schedule:
     - cron: '0 12 * * 1'  # Weekly Monday scans
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,18 @@ name: Security Checks
 on:
   push:
     branches: [ main, security-* ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -3,8 +3,18 @@ name: Test Coverage
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add path filters to security CI/CD workflows to skip unnecessary checks when only documentation files are modified. This optimizes CI resource usage and reduces build times for documentation-only changes.

## Changes

**Path filtering added to workflows:**
- CodeQL SAST analysis (`.github/workflows/codeql.yml`)
- Security checks (`.github/workflows/security.yml`)
- Test coverage (`.github/workflows/test-coverage.yml`)

**Files that skip security checks:**
- `**.md` - All Markdown files (README, CHANGELOG, etc.)
- `docs/**` - Entire docs directory
- `LICENSE` - License file
- `.gitignore` - Git ignore configuration

## Benefits

- ✅ Documentation-only PRs skip expensive security scans
- ✅ Weekly scheduled scans still run (CodeQL every Monday)
- ✅ Code changes always trigger full security suite
- ✅ Saves CI minutes for open source project
- ✅ Faster feedback for documentation updates

## Example

Before: Push README.md → 6 workflows run (CodeQL, 5 security jobs, coverage)
After: Push README.md → 0 workflows run
Code change: All security workflows still run normally

🤖 Generated with Claude Code