### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Update version numbers for the 1.2.1 release, which includes custom vocabulary UX improvements, auto-save indicators, and maintenance updates.

- CFBundleShortVersionString: 1.2.0 → 1.2.1
- CFBundleVersion: 5 → 6