### PR TITLE
Optimize CodeQL workflow to run only on version bumps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,18 +3,12 @@ name: "CodeQL Advanced Security"
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+    paths:
+      - 'Resources/Info.plist'  # Only run on version bumps
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+    paths:
+      - 'Resources/Info.plist'  # Only run on version bumps
   schedule:
     - cron: '0 12 * * 1'  # Weekly Monday scans (runs full security-extended)
 


### PR DESCRIPTION
Reduce CI time by limiting CodeQL analysis to:
- Version changes (Resources/Info.plist modifications)
- Weekly scheduled scans (Mondays at 12:00 UTC)

This prevents the 20-30 minute CodeQL check from running on every PR.