### PR TITLE
Add copy-to-clipboard for update command

### DIFF
--- a/Sources/LookMaNoHands/Models/OnboardingState.swift
+++ b/Sources/LookMaNoHands/Models/OnboardingState.swift
@@ -21,6 +21,9 @@ class OnboardingState {
     var hasMicrophonePermission: Bool = false
     var hasAccessibilityPermission: Bool = false
 
+    // Track if this is a permissions-only flow (skips to permissions step)
+    var isPermissionsOnlyFlow: Bool = false
+
     func nextStep() {
         if let nextStep = Step(rawValue: currentStep.rawValue + 1) {
             currentStep = nextStep

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -1188,12 +1188,21 @@ struct SettingsView: View {
                                 .foregroundColor(.secondary)
                                 .padding(.vertical, 4)
 
-                            Button("View Changes on GitHub") {
-                                if let url = URL(string: update.compareURL) {
-                                    NSWorkspace.shared.open(url)
+                            HStack(spacing: 8) {
+                                Button("View Changes on GitHub") {
+                                    if let url = URL(string: update.compareURL) {
+                                        NSWorkspace.shared.open(url)
+                                    }
                                 }
+                                .controlSize(.small)
+
+                                Button("Copy Command") {
+                                    let pasteboard = NSPasteboard.general
+                                    pasteboard.clearContents()
+                                    pasteboard.setString("git pull && ./scripts/deploy.sh", forType: .string)
+                                }
+                                .controlSize(.small)
                             }
-                            .controlSize(.small)
                         }
                     } else {
                         Image(systemName: "checkmark.circle.fill")


### PR DESCRIPTION
## Summary
- Add "Copy Command" button to update notifications (alert dialog and settings view)
- Users can now copy the update command (`git pull && ./scripts/deploy.sh`) with a single click
- Detect and recover from permission loss after app updates with permissions-only onboarding flow

## Test plan
- Check for app update and verify both buttons work in the alert dialog
- Navigate to Settings and verify the copy button in the update card
- Uninstall app, reinstall it, and verify permission recovery flow triggers if needed

🤖 Generated with Claude Code