### PR TITLE
Refactor MeetingAnalyzeTab layout and improve audio waveform responsiveness (#204)

### DIFF
--- a/Sources/LookMaNoHands/Services/AudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/AudioRecorder.swift
@@ -120,8 +120,9 @@ class AudioRecorder {
                 vDSP_rmsqv(ptr.baseAddress!, 1, &rms, vDSP_Length(bandSamples.count))
             }
 
-            // Amplification (50x) for good visibility
-            let amplified = min(rms * 50.0, 1.0)
+            // Amplification: moderate gain so typical speech sits around 0.4–0.7
+            // rather than constantly peaking at 1.0
+            let amplified = min(rms * 15.0, 1.0)
             bands.append(amplified)
         }
 


### PR DESCRIPTION
## Summary

- Restructure MeetingAnalyzeTab view with fixed header and scrollable content sections
- Move action buttons (Process, Copy, Save) to inline action row above transcript
- Convert static export bar to collapsible transcript and prompt sections
- Improve notes display with markdown rendering and bounded scrollable pane with status badge
- Refine waveform smoothing with asymmetric attack/decay curves for responsive visual feedback
- Reduce audio amplification from 50x to 15x to prevent constant peaking at max volume
- Update deprecated foregroundColor to modern foregroundStyle API throughout

## Test Plan

- [ ] Open a meeting and verify the layout: fixed header with meeting info and type picker, then scrollable content
- [ ] Verify transcript section is expanded by default and can be collapsed
- [ ] Verify prompt section is collapsed by default and can be expanded
- [ ] Run analysis and confirm "Processed" badge appears on notes
- [ ] Confirm waveform responds smoothly without constant peaking
- [ ] Test all copy/save buttons work correctly
- [ ] Verify Cmd+N keyboard shortcut still triggers processing
- [ ] Verify Escape key cancels analysis when in progress

🤖 Generated with Claude Code