### PR TITLE
Fix: Remove DEBUG guard from resolveModelSelection method

### DIFF
--- a/Sources/LookMaNoHands/Views/MeetingAnalyzeTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingAnalyzeTab.swift
@@ -556,7 +556,6 @@ struct MeetingAnalyzeTab: View {
         }
     }
 
-#if DEBUG
     static func resolveModelSelection(models: [String], defaultModel: String) -> (selected: String, available: [String]) {
         let selected: String
         if models.contains(defaultModel) {
@@ -566,7 +565,6 @@ struct MeetingAnalyzeTab: View {
         }
         return (selected, models)
     }
-#endif
 
 #if DEBUG
     var modelSelectionSnapshot: (selected: String, available: [String]) {


### PR DESCRIPTION
The resolveModelSelection method is called in production code (loadModels), so it must be available in all build configurations. Wrapping it in #if DEBUG caused release builds to fail when calling the method that was compiled out.