### PR TITLE
Fix Codecov coverage thresholds for untestable code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 50%
+        threshold: 10%
+
+ignore:
+  - "Sources/LookMaNoHands/Views/**"
+  - "Sources/LookMaNoHands/App/AppDelegate.swift"
+  - "Sources/LookMaNoHands/App/LookMaNoHandsApp.swift"


### PR DESCRIPTION
## Summary

Add a `codecov.yml` configuration file to set reasonable coverage thresholds and exclude code that cannot be meaningfully unit tested.

## Changes

- Configured Codecov to exclude SwiftUI Views (`Sources/LookMaNoHands/Views/**`) which are inherently difficult to unit test
- Excluded app entry point files (`AppDelegate.swift`, `LookMaNoHandsApp.swift`)
- Set patch coverage target to 50% with a 10% threshold (testable logic/services should be covered)
- Set project coverage target to auto with 5% threshold to track progress without blocking on minor fluctuations

## Impact

This resolves the Codecov report warnings on PR #217 which flagged low patch coverage due to 525 missing lines in SwiftUI View files. The configuration allows the team to focus on testing business logic and services while acknowledging that SwiftUI view code is not suitable for unit testing.

🤖 Generated with Claude Code