### PR TITLE
Add app notarization pipeline for distribution (#124)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,47 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Import Developer ID certificate
+        # Skip gracefully when secrets are not configured (e.g. forks)
+        if: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION != '' }}
+        env:
+          CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+
+          # Import certificate
+          echo "$CERTIFICATE_P12" | base64 --decode > /tmp/cert.p12
+          security import /tmp/cert.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          rm /tmp/cert.p12
+
+          # Allow codesign to access the keychain without a prompt
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          # Extract signing identity name and export it for subsequent steps
+          IDENTITY=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "DEVELOPER_ID_APPLICATION=$IDENTITY" >> "$GITHUB_ENV"
+          echo "Signing identity: $IDENTITY"
+
       - name: Build DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: ./scripts/create-dmg.sh "${{ steps.version.outputs.VERSION }}"
+
+      - name: Verify notarization
+        if: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION != '' }}
+        run: |
+          spctl --assess --type open --context context:primary-signature \
+            "build/Look Ma No Hands ${{ steps.version.outputs.VERSION }}.dmg"
+          xcrun stapler validate "build/Look Ma No Hands ${{ steps.version.outputs.VERSION }}.dmg"
+          echo "✅ Notarization staple verified"
 
       - name: Create ZIP archive
         run: |
@@ -72,3 +111,8 @@ jobs:
             build/sbom.cyclonedx.json
             build/sbom.spdx.json
           generate_release_notes: true
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain build.keychain 2>/dev/null || true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate entitlements file
+        run: plutil -lint Resources/LookMaNoHands.entitlements
+
       - name: Build app bundle
         run: ./scripts/deploy.sh
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ swift build -c release
 ./scripts/deploy.sh
 ```
 
+Official releases are built via CI, signed with a Developer ID certificate, notarized by Apple, and stapled — so macOS Gatekeeper trusts them without warnings. See [docs/NOTARIZATION.md](docs/NOTARIZATION.md) for setup instructions if you want to produce your own notarized builds.
+
 ## 👥 Contributing
 
 Contributions welcome! Please read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) first.

--- a/Resources/LookMaNoHands.entitlements
+++ b/Resources/LookMaNoHands.entitlements
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- WhisperKit / Core ML JIT compilation requires unsigned executable memory -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- AVAudioEngine microphone recording for dictation and meeting mode -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- NSAppleScript for media control and app quit -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <!-- URLSession to localhost Ollama and GitHub update checks -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- WhisperKit loads dynamically compiled Core ML models at runtime -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -1,0 +1,106 @@
+# Notarization Setup Guide
+
+This document explains how to configure Apple notarization for Look Ma No Hands so that distributed DMGs install without Gatekeeper warnings.
+
+## Prerequisites
+
+- **Apple Developer Program** membership (paid, $99/year)
+- **Developer ID Application** certificate in your keychain
+- **App-specific password** for your Apple ID (for notarytool)
+- Xcode Command Line Tools installed (`xcode-select --install`)
+
+## How it Works
+
+The release pipeline (`scripts/create-dmg.sh`) detects environment variables at build time:
+
+| Env var set? | Behavior |
+|---|---|
+| No `DEVELOPER_ID_APPLICATION` | Ad-hoc signing (local dev, no Gatekeeper trust) |
+| `DEVELOPER_ID_APPLICATION` only | Developer ID signing + hardened runtime, no notarization |
+| All credentials set | Developer ID signing + notarization + stapling |
+
+## GitHub Secrets Setup
+
+Configure these 6 secrets in **Settings → Secrets and variables → Actions**:
+
+### 1. Export your Developer ID certificate as a .p12
+
+```bash
+# In Keychain Access: right-click your "Developer ID Application: ..." cert → Export
+# Save as certificate.p12 with a strong password
+```
+
+### 2. Base64-encode the .p12
+
+```bash
+base64 -i certificate.p12 | pbcopy   # copies to clipboard
+```
+
+Set this as `APPLE_DEVELOPER_ID_APPLICATION`.
+
+### 3. Set remaining secrets
+
+| Secret | Value |
+|---|---|
+| `APPLE_DEVELOPER_ID_APPLICATION` | Base64-encoded .p12 content |
+| `APPLE_DEVELOPER_ID_APPLICATION_PASSWORD` | Password you set when exporting .p12 |
+| `APPLE_ID` | Your Apple ID email address |
+| `APPLE_TEAM_ID` | 10-character Team ID from [developer.apple.com/account](https://developer.apple.com/account) |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from [appleid.apple.com](https://appleid.apple.com) → Sign-In and Security → App-Specific Passwords |
+| `KEYCHAIN_PASSWORD` | Any random string (used for the ephemeral CI keychain) |
+
+### Finding your Team ID
+
+```bash
+# From command line (if cert is already in your keychain):
+security find-identity -v -p codesigning | grep "Developer ID Application"
+# Team ID is the 10-char string in parentheses at the end, e.g. (ABCD123456)
+```
+
+## Local Notarization Testing
+
+```bash
+export DEVELOPER_ID_APPLICATION="Developer ID Application: Your Name (TEAMID)"
+export APPLE_ID="you@example.com"
+export APPLE_TEAM_ID="ABCD123456"
+export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+
+./scripts/create-dmg.sh 1.3.0
+```
+
+## Verification Commands
+
+```bash
+# Check Gatekeeper assessment
+spctl --assess --type open --context context:primary-signature "build/Look Ma No Hands 1.3.0.dmg"
+
+# Validate stapled notarization ticket
+xcrun stapler validate "build/Look Ma No Hands 1.3.0.dmg"
+
+# Inspect code signature
+codesign -dv --verbose=4 "build/Look Ma No Hands.app"
+
+# Check hardened runtime flag (release builds show "flags=0x10000(runtime)")
+codesign -dv "build/Look Ma No Hands.app" 2>&1 | grep flags
+```
+
+## Troubleshooting
+
+**`errSecInternalComponent` during import**
+- Wrong keychain password or the keychain is locked. Check `KEYCHAIN_PASSWORD` matches what was used to create the keychain.
+
+**`rejected` status from notarytool**
+- Run `xcrun notarytool log <submission-id>` to get the full rejection reason.
+- Common cause: missing hardened runtime flag (`--options runtime`) or a required entitlement.
+
+**`spctl` returns "rejected"**
+- The staple step may have failed, or the ticket hasn't propagated yet (Apple's CDN can take a few minutes).
+- Re-run `xcrun stapler staple` after a few minutes.
+
+**`codesign: object file format unrecognized` on deep signing**
+- This can happen with some Swift build artifacts. The `--deep` flag is only used in `create-dmg.sh` (release); `deploy.sh` intentionally omits it.
+
+**Notarization works locally but not in CI**
+- Verify all 6 secrets are set and not empty.
+- Check that the `APPLE_DEVELOPER_ID_APPLICATION` secret contains valid base64 (no line breaks).
+- The certificate import step is skipped when `secrets.APPLE_DEVELOPER_ID_APPLICATION` is empty, so the DMG falls back to ad-hoc signing.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -128,14 +128,14 @@ All results are available as GitHub workflow artifacts and visible in pull reque
 - **Entitlements verification** — CI confirms app only requests necessary system permissions
 - **Release provenance** — every release ships with SHA-256 checksums and a Software Bill of Materials (SBOM)
 - **Safe build scripts** — destructive operations guarded, user settings preserved by default
+- **Notarized releases** — distributed DMGs are signed with a Developer ID, notarized by Apple, and stapled so Gatekeeper trusts them without warnings (see [docs/NOTARIZATION.md](NOTARIZATION.md))
 
 ### Known limitations / future work
 
 | Item | Issue | Notes |
 |------|-------|-------|
-| App notarization and hardened runtime | [#124](https://github.com/qaid/look-ma-no-hands/issues/124) | Requires Apple Developer Program membership; ad-hoc signing works for local use |
 | Update signature checks accept ad-hoc signatures | — | Production distribution should verify a specific Developer ID |
-| No App Sandbox | — | Disabled because Accessibility and ScreenCaptureKit APIs require it; entitlements file is prepared for when hardened runtime is enabled |
+| No App Sandbox | — | Disabled because Accessibility and ScreenCaptureKit APIs require it; entitlements file covers all required permissions for hardened runtime |
 
 ## Reporting a Vulnerability
 

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -7,6 +7,7 @@ VERSION="${1:-1.0}"
 DMG_NAME="Look Ma No Hands ${VERSION}.dmg"
 BUILD_DIR="build"
 APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
+ENTITLEMENTS="Resources/LookMaNoHands.entitlements"
 
 echo "Building ${APP_NAME} v${VERSION}..."
 swift build -c release
@@ -28,8 +29,21 @@ if [ -f "Resources/AppIcon.icns" ]; then
     cp "Resources/AppIcon.icns" "${APP_PATH}/Contents/Resources/AppIcon.icns"
 fi
 
-# Ad-hoc code sign
-codesign --force --sign - "${APP_PATH}"
+# Code sign: Developer ID (release) or ad-hoc (local dev)
+if [ -n "${DEVELOPER_ID_APPLICATION}" ]; then
+    echo "Signing with Developer ID: ${DEVELOPER_ID_APPLICATION}"
+    codesign --force --options runtime \
+        --sign "${DEVELOPER_ID_APPLICATION}" \
+        --entitlements "${ENTITLEMENTS}" \
+        --deep \
+        "${APP_PATH}"
+    # Verify signature
+    codesign --verify --deep --strict "${APP_PATH}"
+    echo "✅ Developer ID signature verified"
+else
+    echo "No DEVELOPER_ID_APPLICATION set — using ad-hoc signing"
+    codesign --force --sign - "${APP_PATH}"
+fi
 
 echo "Creating DMG..."
 [ -f "${BUILD_DIR}/${DMG_NAME}" ] && rm -f "${BUILD_DIR}/${DMG_NAME}"
@@ -47,7 +61,35 @@ hdiutil create -volname "${APP_NAME}" \
     -ov -format UDZO \
     "${BUILD_DIR}/${DMG_NAME}"
 
-# Clean up
+# Clean up temp dir
 [ -d "${DMG_TEMP}" ] && rm -rf "${DMG_TEMP}"
+
+# Sign the DMG with Developer ID if available
+if [ -n "${DEVELOPER_ID_APPLICATION}" ]; then
+    echo "Signing DMG with Developer ID..."
+    codesign --force --sign "${DEVELOPER_ID_APPLICATION}" "${BUILD_DIR}/${DMG_NAME}"
+fi
+
+# Notarize and staple if credentials are provided
+if [ -n "${DEVELOPER_ID_APPLICATION}" ] && [ -n "${APPLE_ID}" ] && [ -n "${APPLE_TEAM_ID}" ] && [ -n "${APPLE_APP_SPECIFIC_PASSWORD}" ]; then
+    echo "Submitting DMG for notarization..."
+    xcrun notarytool submit "${BUILD_DIR}/${DMG_NAME}" \
+        --apple-id "${APPLE_ID}" \
+        --team-id "${APPLE_TEAM_ID}" \
+        --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+        --wait \
+        --timeout 30m
+
+    echo "Stapling notarization ticket to DMG..."
+    xcrun stapler staple "${BUILD_DIR}/${DMG_NAME}"
+
+    echo "Verifying notarization..."
+    spctl --assess --type open --context context:primary-signature "${BUILD_DIR}/${DMG_NAME}"
+    echo "✅ Notarization verified"
+else
+    if [ -n "${DEVELOPER_ID_APPLICATION}" ]; then
+        echo "Notarization credentials not set — skipping notarization (APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD required)"
+    fi
+fi
 
 echo "DMG created: ${BUILD_DIR}/${DMG_NAME}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -96,7 +96,7 @@ cp ".build/release/LookMaNoHands" "$APP_PATH/Contents/MacOS/LookMaNoHands"
 chmod +x "$APP_PATH/Contents/MacOS/LookMaNoHands"
 
 # Code sign the app to bind Info.plist (without --deep to avoid invalidating the signature)
-codesign --force --sign - "$APP_PATH"
+codesign --force --sign - --entitlements Resources/LookMaNoHands.entitlements "$APP_PATH"
 
 # Update Launch Services to recognize the new bundle name
 echo "🔄 Updating Launch Services database..."

--- a/scripts/verify-entitlements.sh
+++ b/scripts/verify-entitlements.sh
@@ -32,25 +32,48 @@ plutil -lint /tmp/entitlements.plist || {
 echo ""
 echo "=== Required Entitlements Check ==="
 
-# Required: Microphone access (for dictation)
-if ! grep -q "com.apple.security.device.microphone" /tmp/entitlements.plist; then
-    echo "❌ Missing required entitlement: com.apple.security.device.microphone"
+# Required: Microphone access (hardened runtime key for AVAudioEngine)
+if ! grep -q "com.apple.security.device.audio-input" /tmp/entitlements.plist; then
+    echo "❌ Missing required entitlement: com.apple.security.device.audio-input"
+    rm /tmp/entitlements.plist
     exit 1
 fi
-echo "✅ Microphone entitlement present"
+echo "✅ Audio input entitlement present"
 
-# Required: Accessibility (for text insertion)
+# Required: Apple Events for NSAppleScript (media control, app quit)
 if ! grep -q "com.apple.security.automation.apple-events" /tmp/entitlements.plist; then
     echo "⚠️  Warning: Missing com.apple.security.automation.apple-events"
 fi
 
-echo ""
-echo "=== Forbidden Entitlements Check ==="
+# Expected: Network client for Ollama and GitHub update checks
+if ! grep -q "com.apple.security.network.client" /tmp/entitlements.plist; then
+    echo "⚠️  Warning: Missing com.apple.security.network.client (needed for Ollama + update checks)"
+else
+    echo "✅ Network client entitlement present (Ollama + GitHub updates)"
+fi
 
-# Forbidden: Network client (app should NOT make network requests except updates)
-# Note: Update service is exception - validate in code review
-if grep -q "com.apple.security.network.client" /tmp/entitlements.plist; then
-    echo "⚠️  Network client entitlement present (verify this is intentional)"
+# Expected: WhisperKit / Core ML JIT compilation
+if ! grep -q "com.apple.security.cs.allow-unsigned-executable-memory" /tmp/entitlements.plist; then
+    echo "⚠️  Warning: Missing com.apple.security.cs.allow-unsigned-executable-memory (needed for WhisperKit)"
+else
+    echo "✅ Unsigned executable memory entitlement present (WhisperKit/Core ML)"
+fi
+
+# Expected: WhisperKit dynamically compiled Core ML models
+if ! grep -q "com.apple.security.cs.disable-library-validation" /tmp/entitlements.plist; then
+    echo "⚠️  Warning: Missing com.apple.security.cs.disable-library-validation (needed for WhisperKit Core ML models)"
+else
+    echo "✅ Library validation disabled (WhisperKit Core ML models)"
+fi
+
+echo ""
+echo "=== Hardened Runtime Check (release builds) ==="
+
+# Check hardened runtime flag (set by --options runtime during Developer ID signing)
+if codesign -dv "$APP_PATH" 2>&1 | grep -q "flags=0x10000(runtime)"; then
+    echo "✅ Hardened runtime enabled"
+else
+    echo "ℹ️  Hardened runtime not enabled (expected for ad-hoc / local dev builds)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Implements Apple notarization for the release pipeline, enabling distributed DMGs to install without Gatekeeper warnings. The pipeline now supports Developer ID code signing, Apple notarization, and hardened runtime entitlements, with full backward compatibility for local ad-hoc development builds.

## Key Changes

- **Resources/LookMaNoHands.entitlements** — New hardened runtime entitlements covering audio input, Apple events, network access, and Core ML compilation
- **scripts/create-dmg.sh** — Conditional Developer ID signing with optional notarization and stapling workflow
- **scripts/deploy.sh** — Embed entitlements during ad-hoc signing for CI validation
- **scripts/verify-entitlements.sh** — Enhanced validation including hardened runtime checks
- **GitHub Workflows** — Release workflow imports certificates and handles notarization; security workflow validates entitlements file
- **Documentation** — New NOTARIZATION.md guide with setup instructions, local testing, and troubleshooting

## Test Plan

- [ ] Verify entitlements file is valid plist: `plutil -lint Resources/LookMaNoHands.entitlements`
- [ ] Test local build without env vars: `./scripts/create-dmg.sh 1.3.0` (should use ad-hoc fallback)
- [ ] Verify entitlements check passes: `./scripts/deploy.sh && ./scripts/verify-entitlements.sh ~/Applications/"Look Ma No Hands.app"`
- [ ] Review release.yml certificate import logic and secret references
- [ ] Confirm security.yml entitlements validation step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)