### PR TITLE
Fix dictation unresponsive after meeting recording (Issue #221)

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,13 @@
+Run the deploy script to build and deploy the app to ~/Applications:
+
+```bash
+./scripts/deploy.sh
+```
+
+If the user passes `--reset-defaults`, run with that flag:
+
+```bash
+./scripts/deploy.sh --reset-defaults
+```
+
+Wait for the script to complete and report the result to the user.

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -924,7 +924,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if transcriptionState.isRecording {
             print("Stopping recording...")
             stopRecordingAndTranscribe()
-        } else if transcriptionState.recordingState == .idle {
+        } else if transcriptionState.recordingState == .idle ||
+                  transcriptionState.recordingState.isError {
+            if transcriptionState.recordingState.isError {
+                print("Recovering from error state, resetting...")
+                transcriptionState.reset()
+            }
             print("Starting recording...")
             startRecording()
         } else {
@@ -1267,6 +1272,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
                 await MainActor.run {
                     self.transcriptionState.setError("Processing failed: \(error.localizedDescription)")
+                    // Auto-recover from error state after 3 seconds
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .seconds(3))
+                        if self.transcriptionState.recordingState.isError {
+                            self.transcriptionState.reset()
+                        }
+                    }
                 }
             }
         }.value

--- a/Sources/LookMaNoHands/Models/TranscriptionState.swift
+++ b/Sources/LookMaNoHands/Models/TranscriptionState.swift
@@ -26,6 +26,11 @@ enum RecordingState: Equatable {
             return "Error: \(message)"
         }
     }
+
+    var isError: Bool {
+        if case .error = self { return true }
+        return false
+    }
 }
 
 /// Central state management for the transcription pipeline

--- a/Sources/LookMaNoHands/Services/ContinuousTranscriber.swift
+++ b/Sources/LookMaNoHands/Services/ContinuousTranscriber.swift
@@ -64,6 +64,11 @@ class ContinuousTranscriber {
         self.whisperService = whisperService
     }
 
+    deinit {
+        isTranscribing = false
+        audioBuffer.removeAll()
+    }
+
     // MARK: - Session Control
 
     /// Start a new transcription session

--- a/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
+++ b/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
@@ -99,6 +99,16 @@ class KeyboardMonitor {
             guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
 
             let monitor = Unmanaged<KeyboardMonitor>.fromOpaque(refcon).takeUnretainedValue()
+
+            // macOS disables the tap if the callback takes too long — re-enable it
+            if type == .tapDisabledByTimeout {
+                if let tap = monitor.eventTap {
+                    CGEvent.tapEnable(tap: tap, enable: true)
+                }
+                NSLog("⚠️ KeyboardMonitor: Event tap re-enabled after timeout")
+                return Unmanaged.passUnretained(event)
+            }
+
             let shouldConsume = monitor.handleEvent(type: type, event: event)
 
             // If handleEvent returned true, consume the event (return nil) to prevent system handling

--- a/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/MixedAudioRecorder.swift
@@ -36,6 +36,13 @@ class MixedAudioRecorder {
         setupSystemAudioCallback()
     }
 
+    deinit {
+        if isRecording {
+            _ = microphoneRecorder.stopRecording()
+            isRecording = false
+        }
+    }
+
     // MARK: - Recording Control
 
     /// Start capturing and mixing both audio sources

--- a/Sources/LookMaNoHands/Services/SystemAudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/SystemAudioRecorder.swift
@@ -20,9 +20,6 @@ class SystemAudioRecorder: NSObject {
     /// Audio stream from ScreenCaptureKit
     private var stream: SCStream?
 
-    /// Audio engine for processing captured audio
-    private let audioEngine = AVAudioEngine()
-
     /// Buffer to store captured audio samples
     private var audioBuffer: [Float] = []
     private let bufferLock = NSLock()  // Thread-safe access to audioBuffer
@@ -35,6 +32,14 @@ class SystemAudioRecorder: NSObject {
 
     /// Callback for audio data chunks
     var onAudioChunk: (([Float]) -> Void)?
+
+    deinit {
+        if isRecording {
+            stream?.stopCapture { _ in }
+            stream = nil
+            isRecording = false
+        }
+    }
 
     // MARK: - Permissions
 

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -3,7 +3,7 @@ import WhisperKit
 
 /// Service for transcribing audio using the local Whisper model
 /// Uses WhisperKit by Argmax with Apple Silicon optimizations
-/// Thread safety is handled internally by WhisperKit
+/// Serializes transcribe() calls to prevent concurrent access from dictation and meeting mode
 class WhisperService: @unchecked Sendable {
 
     // MARK: - Properties
@@ -22,6 +22,10 @@ class WhisperService: @unchecked Sendable {
 
     /// Name of the currently loaded model (e.g., "base", "large-v3-turbo")
     private(set) var loadedModelName: String?
+
+    /// Lock to serialize transcription calls (shared between dictation and meeting mode)
+    private let transcriptionLock = NSLock()
+    private var isTranscribing = false
     
     // MARK: - Initialization
 
@@ -92,6 +96,23 @@ class WhisperService: @unchecked Sendable {
 
         guard !samples.isEmpty else {
             throw WhisperError.emptyAudio
+        }
+
+        // Serialize transcription calls — prevents concurrent access from dictation and meeting mode
+        // which can corrupt WhisperKit state and cause long blocking that disables the CGEvent tap
+        while true {
+            let acquired = transcriptionLock.withLock {
+                if !isTranscribing {
+                    isTranscribing = true
+                    return true
+                }
+                return false
+            }
+            if acquired { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        defer {
+            transcriptionLock.withLock { isTranscribing = false }
         }
 
         let startTime = Date()


### PR DESCRIPTION
## Changes

- **Transcription State**: Added `isError` property to `RecordingState` for easier error checking and recovery
- **AppDelegate**: 
  - Allow starting recording from error state with automatic reset
  - Add auto-recovery from error state after 3 seconds
- **WhisperService**: Serialize transcription calls with lock to prevent concurrent access from dictation and meeting mode that corrupts state
- **ContinuousTranscriber**: Add deinit to clean up resources
- **MixedAudioRecorder**: Add deinit to ensure recording is stopped
- **SystemAudioRecorder**: Add deinit to properly stop stream capture and clean up
- **KeyboardMonitor**: Handle tap timeout by re-enabling event tap to prevent keyboard unresponsiveness
- **Documentation**: Add deploy command documentation

## Root Cause
Concurrent transcription calls from dictation and meeting mode were corrupting WhisperKit state, causing long blocking operations that disabled the CGEvent tap and made the app unresponsive.