### PR TITLE
Fix meeting window empty space when transcript collapsed

### DIFF
--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -326,6 +326,8 @@ struct MeetingRecordTab: View {
                 }
                 .frame(minHeight: 200, maxHeight: .infinity)
                 .transition(.opacity.combined(with: .move(edge: .top)))
+            } else {
+                Spacer(minLength: 0)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes issue #226 where a large empty space appeared above the recording controls when the transcript section was collapsed.

## Root Cause
When `showTranscript` was false, the flexible `HStack` inside `transcriptView` was removed from the view hierarchy, causing the body `VStack` to shrink below the window's full height. The TabView then vertically centered the undersized content, creating the unwanted empty space.

## Solution
Added `Spacer(minLength: 0)` in the else branch of the transcript toggle. This keeps `transcriptView` as a flexible child of the body `VStack` at all times, ensuring content stays anchored to the top regardless of collapse state.

## Testing
- Collapse and expand the Transcription section multiple times — recording controls remain at the top
- No empty space appears above recording status information
- Existing tests pass: `swift test --filter MeetingRecordTests`

Resolves #226