### PR TITLE
Polish permission button sizes and remove extra hint text (Issue #233)

### DIFF
--- a/Sources/LookMaNoHands/Views/OnboardingView.swift
+++ b/Sources/LookMaNoHands/Views/OnboardingView.swift
@@ -567,8 +567,7 @@ struct PermissionsStepView: View {
                     actionTitle: "Open System Settings",
                     action: {
                         openAccessibilitySettings()
-                    },
-                    extraInfo: onboardingState.hasAccessibilityPermission ? nil : "You'll need to manually enable accessibility in System Settings"
+                    }
                 )
             }
             .frame(maxWidth: 550)
@@ -673,7 +672,6 @@ struct PermissionCard: View {
     let isGranted: Bool
     let actionTitle: String
     let action: () -> Void
-    var extraInfo: String? = nil
 
     var body: some View {
         HStack(spacing: 15) {
@@ -691,13 +689,6 @@ struct PermissionCard: View {
                 Text(description)
                     .font(.caption)
                     .foregroundColor(.secondary)
-
-                if let extraInfo = extraInfo {
-                    Text(extraInfo)
-                        .font(.caption2)
-                        .foregroundColor(.orange)
-                        .padding(.top, 2)
-                }
             }
 
             Spacer()
@@ -713,7 +704,6 @@ struct PermissionCard: View {
                         .font(.caption)
                 }
                 .buttonStyle(.bordered)
-                .controlSize(.small)
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- Removed `.controlSize(.small)` from PermissionCard action buttons so they match the "Done" button height
- Removed redundant orange "You'll need to manually enable accessibility in System Settings" helper text from the Accessibility card
- Cleaned up the unused `extraInfo` property and rendering logic from `PermissionCard`

Closes #233

## Test plan
- [ ] Build succeeds: `swift build -c release`
- [ ] Launch app, trigger onboarding flow — verify action buttons are taller and match "Done" button height
- [ ] Verify no orange helper text appears on the Accessibility card
- [ ] Trigger "Re-grant Permissions" flow — verify same fixes apply