### PR TITLE
Fix: Meeting window not restoring after screen recording permission grant

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -573,6 +573,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
 
         Settings.shared.meetingWindowWasOpen = true
+        UserDefaults.standard.synchronize()
         NSLog("✅ Meeting Transcription window created and displayed")
     }
     

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -88,12 +88,6 @@ struct MeetingRecordTab: View {
                 Settings.shared.pendingScreenRecordingGrant = true
                 UserDefaults.standard.synchronize()
                 CGRequestScreenCaptureAccess()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                    checkStatus()
-                    if liveState.status == .missingPermissions {
-                        Settings.shared.pendingScreenRecordingGrant = false
-                    }
-                }
             }
         }
         .onDisappear {
@@ -603,12 +597,6 @@ struct MeetingRecordTab: View {
             Settings.shared.pendingScreenRecordingGrant = true
             UserDefaults.standard.synchronize()
             CGRequestScreenCaptureAccess()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                checkStatus()
-                if liveState.status == .missingPermissions {
-                    Settings.shared.pendingScreenRecordingGrant = false
-                }
-            }
         } else if liveState.canRecord {
             Task { await startRecording() }
         }
@@ -756,6 +744,9 @@ struct MeetingRecordTab: View {
         if !SystemAudioRecorder.hasPermission() {
             liveState.status = .missingPermissions
             return
+        }
+        if Settings.shared.pendingScreenRecordingGrant {
+            Settings.shared.pendingScreenRecordingGrant = false
         }
         liveState.status = .ready
     }


### PR DESCRIPTION
## Summary
- Removed premature clearing of `pendingScreenRecordingGrant` flag that was defeating the window restore mechanism
- The 1-second delayed check was clearing the flag while the user was still in System Settings
- Flag is now only cleared when permissions are actually confirmed granted or on relaunch
- Added `UserDefaults.synchronize()` to ensure `meetingWindowWasOpen` survives force-termination

## Context
PR #236 attempted to fix Issue #232 by adding the `pendingScreenRecordingGrant` flag, but the implementation had a subtle bug: 1-second delayed checks were clearing the flag before macOS force-killed the app (which happens seconds after the user grants permission). This fix removes those premature clears.

## Testing
- Build succeeds: `swift build -c release`
- All tests pass: 52/52 passing
- Manual: Open Meeting window → Record tab → trigger permission flow → grant permission → app should now auto-restore to Record tab

Closes #232