### PR TITLE
Improve 1:1 meeting transcript analysis prompt (Issue #252)

### DIFF
--- a/Sources/LookMaNoHands/Services/BuildInfo.swift
+++ b/Sources/LookMaNoHands/Services/BuildInfo.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Build information injected by deploy.sh at build time.
 /// This file is checked in with placeholder values for development builds.
 struct BuildInfo {
-    static let commitSHA = "85b2097c8b39dc0f1e43c829e4cd0410dc1a1b6f"
-    static let commitShortSHA = "85b2097"
-    static let buildDate = "2026-03-04 10:00:50 UTC"
-    static let branch = "fix/meeting-one-to-one-transcript-quality"
+    static let commitSHA = "development"
+    static let commitShortSHA = "dev"
+    static let buildDate = ""
+    static let branch = "unknown"
 }

--- a/Tests/LookMaNoHandsTests/MeetingTypeTests.swift
+++ b/Tests/LookMaNoHandsTests/MeetingTypeTests.swift
@@ -36,6 +36,25 @@ final class MeetingTypeTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Complete All Sections"), "Missing 'Complete All Sections' quality guard")
     }
 
+    func testOneOnOnePromptSections() {
+        let prompt = MeetingType.oneOnOne.defaultPrompt
+        // Verify all required output sections exist
+        XCTAssertTrue(prompt.contains("Meeting Context"), "Missing Meeting Context section")
+        XCTAssertTrue(prompt.contains("Key Discussion Points"), "Missing Key Discussion Points section")
+        XCTAssertTrue(prompt.contains("Feedback & Recognition"), "Missing Feedback & Recognition section")
+        XCTAssertTrue(prompt.contains("Goals & Career Development"), "Missing Goals & Career Development section")
+        XCTAssertTrue(prompt.contains("Concerns & Blockers"), "Missing Concerns & Blockers section")
+        XCTAssertTrue(prompt.contains("Decisions Made"), "Missing Decisions Made section")
+        XCTAssertTrue(prompt.contains("Action Items"), "Missing Action Items section")
+        XCTAssertTrue(prompt.contains("Open Questions"), "Missing Open Questions section")
+        XCTAssertTrue(prompt.contains("Notable Quotes"), "Missing Notable Quotes section")
+        XCTAssertTrue(prompt.contains("Follow-Up"), "Missing Follow-Up section")
+        // Verify quality guards
+        XCTAssertTrue(prompt.contains("Never Invent"), "Missing 'Never Invent' quality guard")
+        XCTAssertTrue(prompt.contains("[Unclear]"), "Missing [Unclear] marker instruction")
+        XCTAssertTrue(prompt.contains("Complete All Sections"), "Missing 'Complete All Sections' quality guard")
+    }
+
     func testDefaultPromptBehavior() {
         XCTAssertTrue(MeetingType.standup.defaultPrompt.contains("[TRANSCRIPTION_PLACEHOLDER]"))
         XCTAssertTrue(MeetingType.oneOnOne.defaultPrompt.contains("[TRANSCRIPTION_PLACEHOLDER]"))


### PR DESCRIPTION
## Summary

Rewrite the `oneOnOne` meeting type prompt from a minimal 15-line template to a comprehensive ~130-line prompt that captures substantive 1:1 meeting details. The enhanced prompt includes core processing rules for noise filtering, speaker attribution, and capturing specifics, plus 12 structured output sections: Meeting Context, Key Discussion Points, Feedback & Recognition, Goals & Career Development, Concerns & Blockers, Decisions Made, Action Items (table), Open Questions, Notable Quotes, and Follow-Up.

## Changes

- Expanded `oneOnOne` defaultPrompt in `MeetingType.swift` with detailed processing rules and structured output format matching the depth and sophistication of existing `videoEssay` and `general` prompts
- Retained `/no_think` prefix and `[TRANSCRIPTION_PLACEHOLDER]` for MeetingAnalyzer compatibility

## Verification

- ✅ `swift build` succeeds
- ✅ `swift test --filter MeetingTypeTests` passes (all 3 tests)
- ✅ Prompt includes required `[TRANSCRIPTION_PLACEHOLDER]` marker

🤖 Generated with Claude Code