### PR TITLE
Fix meeting window missing from Cmd+Tab and rename menu item

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -408,7 +408,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Meeting transcription
         let meetingItem = NSMenuItem(
-            title: "Start Meeting Transcription...",
+            title: "Meeting Recordings...",
             action: #selector(openMeetingTranscription),
             keyEquivalent: "m"
         )
@@ -556,6 +556,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // Switch to regular app mode so window appears in Dock and Cmd+Tab
+        NSApp.setActivationPolicy(.regular)
+
         // If window already exists, just bring it to front
         if let window = meetingWindow {
             window.makeKeyAndOrderFront(nil)
@@ -585,9 +588,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentView = hostingView
 
         self.meetingWindow = window
-
-        // Change activation policy to regular app so window appears in Cmd+Tab
-        NSApp.setActivationPolicy(.regular)
 
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
## Summary
- Move `setActivationPolicy(.regular)` before the existing-window check in `openMeetingTranscription()`, matching the pattern used in `openSettings()` — fixes the meeting window not appearing in Cmd+Tab when re-opened from minimized state
- Rename menu bar item from "Start Meeting Transcription..." to "Meeting Recordings..."

Closes #256

## Test plan
- [ ] Open meeting window → appears in Cmd+Tab
- [ ] Minimize meeting window → reopen → still in Cmd+Tab
- [ ] Close meeting window → removed from Cmd+Tab
- [ ] Menu bar dropdown shows "Meeting Recordings..."
- [ ] `swift build -c release` succeeds
- [ ] `swift test` passes (88/88)