### PR TITLE
Fix type picker on Analyze tab not responding to clicks (#258)

### DIFF
--- a/Sources/LookMaNoHands/Views/MeetingAnalyzeTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingAnalyzeTab.swift
@@ -224,6 +224,7 @@ struct MeetingAnalyzeTab: View {
                 }
                 .pickerStyle(.menu)
                 .labelsHidden()
+                .frame(minWidth: 140)
             }
 
             Rectangle()


### PR DESCRIPTION
Fixes #258

The TYPE picker on the Analyze tab wasn't responding to clicks because it lacked a frame width constraint. Adding `.frame(minWidth: 140)` ensures the picker has a sufficient clickable area, matching the model picker's pattern.

Build tested: `swift build -c release` completes with no warnings.