### PR TITLE
Fix screen recording permission dialog hidden behind meeting window (#264)

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -604,9 +604,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         meetingWindow?.orderOut(nil)
     }
 
-    /// Restore the meeting window after the user returns from the permission flow
+    /// Restore the meeting window after the user returns from the permission flow.
+    /// Guards against redundant activation when the window is already visible.
     func restoreMeetingWindowAfterPermission() {
-        meetingWindow?.makeKeyAndOrderFront(nil)
+        guard let window = meetingWindow, !window.isVisible else { return }
+        window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -34,6 +34,7 @@ struct MeetingRecordTab: View {
     @State private var lastSubmittedNoteID: UUID?
     @State private var noteAboveCount = 0
     @State private var scrollViewHeight: CGFloat = 0
+    @State private var permissionWorkItem: DispatchWorkItem?
 
     // MARK: - Init
 
@@ -96,6 +97,8 @@ struct MeetingRecordTab: View {
         }
         .onDisappear {
             liveState.isActive = false
+            permissionWorkItem?.cancel()
+            permissionWorkItem = nil
             stopAudioLevelUpdates()
             if liveState.isRecording {
                 Task { await stopRecording() }
@@ -622,10 +625,12 @@ struct MeetingRecordTab: View {
         UserDefaults.standard.synchronize()
         appDelegate?.minimizeMeetingWindowForPermission()
         // Delay permission request so the window hides first, ensuring the
-        // macOS System Settings dialog appears visibly in the foreground
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            CGRequestScreenCaptureAccess()
-        }
+        // macOS System Settings dialog appears visibly in the foreground.
+        // Use a cancellable work item so disappearing the view cancels the request.
+        permissionWorkItem?.cancel()
+        let workItem = DispatchWorkItem { CGRequestScreenCaptureAccess() }
+        permissionWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
     }
 
     private func handleRecordingToggle() {


### PR DESCRIPTION
## Summary

- Replace `miniaturize(nil)` with `orderOut(nil)` in `minimizeMeetingWindowForPermission()` — miniaturize hides the window to an invisible Dock since the app uses `.accessory` activation policy
- Add `restoreMeetingWindowAfterPermission()` to bring the meeting window back when the user returns from System Settings
- Extract duplicated permission request logic into `requestScreenRecordingPermission()` with a 0.3s delay so the window hides before `CGRequestScreenCaptureAccess()` fires
- Add `.onReceive(NSApplication.didBecomeActiveNotification)` observer to auto-restore the window when the app regains focus

Closes #264

## Test plan

- [ ] Open Meeting Recording on a system without Screen Recording permission granted
- [ ] Verify the macOS System Settings permission dialog is visible (not hidden behind the meeting window)
- [ ] Verify the meeting window reappears when returning to the app from System Settings
- [ ] Verify the existing `pendingScreenRecordingGrant` relaunch flow still works after granting permission
- [ ] Verify clicking the record button also correctly surfaces the permission dialog