### PR TITLE
Cap notarization timeout at 5 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Notarize DMG
         if: env.HAS_SIGNING_CERT == 'true'
         continue-on-error: true
+        timeout-minutes: 5
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 5` to the notarize step so the release pipeline doesn't block for 30+ minutes
- Apple notarization is consistently timing out — needs separate investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)