### PR TITLE
Remove redundant post-merge build jobs from CI workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,6 +55,7 @@ jobs:
 
   build-verification:
     name: Verify Clean Build
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/security-')
     runs-on: macos-14
     steps:
       - name: Checkout code
@@ -116,6 +117,7 @@ jobs:
 
   entitlements-check:
     name: Verify App Entitlements
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/security-')
     runs-on: macos-14
     steps:
       - name: Checkout code

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,13 +1,6 @@
 name: Test Coverage
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
     branches: [ main ]
     paths-ignore:


### PR DESCRIPTION
## Summary

- Added `if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/security-')` to `build-verification` and `entitlements-check` jobs in `security.yml` — these expensive macOS jobs (~2min and ~1.5min) now only run on PRs and `security-*` branches, not on every merge to `main`
- Removed the `push` trigger from `test-coverage.yml` (Option B) — tests run pre-merge on PRs only; post-merge coverage upload on `main` is skipped in favour of eliminating the ~3min macOS runner cost per merge

Fast safety-net jobs (`secret-scan`, `dependency-scan`, `verify-dependencies`) are unaffected and continue running on both push and PR triggers.

## Decision: test-coverage.yml Option B (PR-only)

Coverage trends on `main` via Codecov were deemed lower-value than the runner cost savings (~3+ min macOS-14 per merge). Coverage is still measured on every PR before code reaches `main`.

## Test plan

- [ ] Merge a PR to `main` → confirm `Verify Clean Build` and `Verify App Entitlements` jobs are skipped
- [ ] Merge a PR to `main` → confirm `Scan for Secrets`, `Scan Dependencies for Vulnerabilities`, and `Verify Package.resolved Integrity` still run
- [ ] Open a PR targeting `main` → confirm all jobs run (build, entitlements, tests, security scans)
- [ ] Push to a `security-*` branch → confirm `build-verification` and `entitlements-check` still run

Closes #273