### PR TITLE
Fix meeting recording window bugs

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -577,7 +577,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.title = "Meetings"
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 600, height: 450)
+        window.minSize = NSSize(width: 700, height: 450)
         window.maxSize = NSSize(width: 1400, height: 1200)
         window.setFrameAutosaveName("MeetingTranscriptionWindow")
         window.delegate = self

--- a/Sources/LookMaNoHands/Views/MeetingView.swift
+++ b/Sources/LookMaNoHands/Views/MeetingView.swift
@@ -69,9 +69,7 @@ struct MeetingView: View {
                 recordingIndicator: recordingIndicator,
                 appDelegate: appDelegate
             ) { record in
-                // After auto-save, select the new meeting and switch to Analyze
                 selectedMeeting = record
-                selectedTab = .analyze
             }
             .tabItem {
                 Label(MeetingTab.record.rawValue, systemImage: MeetingTab.record.icon)


### PR DESCRIPTION
## Summary
- Remove auto-navigation to Analyze tab when a recording finishes (user now stays on Record tab)
- Increase window minimum width from 600px to 700px to prevent the Analyze tab from appearing cramped

These changes address layout and navigation issues in the Meeting Recording window.