### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Increment app version from 1.3.0 to 1.4.0 (build 8) in preparation for release. This enables the automated release workflow when a v1.4.0 tag is pushed.