### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- Bump version to 1.4.1 (build 9) for patch release covering bug fixes merged after v1.4.0

## Changes since v1.4.0

- Fix release styling: window appearance and SPM resources (#292)
- Fix meeting recording waveform visualizer not responding to audio (#290)
- Close auto-opened Settings window on launch (#291)

## Test plan

- [ ] `swift build` succeeds
- [ ] `swift test` passes
- [ ] Deploy and verify version shows 1.4.1