### PR TITLE
Fix DMG mount point parsing in build script

### DIFF
--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -78,9 +78,10 @@ hdiutil create -volname "${APP_NAME}" \
 [ -d "${DMG_TEMP}" ] && rm -rf "${DMG_TEMP}"
 
 # Phase B — Mount, copy background, style via AppleScript
-MOUNT_DIR=$(hdiutil attach -readwrite -noverify "${TEMP_DMG}" | sed -n 's|.*\(/Volumes/.*\)|\1|p' | head -1)
-if [ -z "${MOUNT_DIR}" ]; then
-    echo "ERROR: Failed to mount DMG — could not determine mount point"
+MOUNT_DIR="/Volumes/${APP_NAME}"
+hdiutil attach -readwrite -noverify -mountpoint "${MOUNT_DIR}" "${TEMP_DMG}"
+if [ ! -d "${MOUNT_DIR}" ]; then
+    echo "ERROR: Failed to mount DMG at ${MOUNT_DIR}"
     rm -f "${TEMP_DMG}"
     exit 1
 fi
@@ -111,8 +112,8 @@ if [ -f "Resources/dmg-background.png" ]; then
     cp Resources/dmg-background.png "${MOUNT_DIR}/.background/background.png"
 fi
 
-# Style the DMG window with AppleScript
-osascript <<APPLESCRIPT
+# Style the DMG window with AppleScript (non-fatal — may fail in headless CI)
+if ! osascript <<APPLESCRIPT
 tell application "Finder"
     tell disk "${APP_NAME}"
         open
@@ -134,6 +135,9 @@ tell application "Finder"
     end tell
 end tell
 APPLESCRIPT
+then
+    echo "⚠️  DMG styling via AppleScript failed (expected in headless CI) — continuing without styling"
+fi
 
 # Phase C — Detach and convert to compressed read-only
 sync


### PR DESCRIPTION
## Summary

Fixed a critical DMG build failure in CI caused by fragile output parsing of `hdiutil attach`. The sed pattern was matching only the last path segment ("Hands") instead of the full mount path ("/Volumes/Look Ma No Hands"), causing background files to be copied to the wrong location.

## Changes

- Replace sed-based mount point extraction with explicit `-mountpoint` flag to `hdiutil attach`
- Wrap Finder AppleScript styling in non-fatal error handling since it fails in headless GitHub Actions environments
- DMG creation now succeeds in CI with or without AppleScript styling

## Test Plan

- CI release builds should now complete successfully
- DMG background and layout will be applied on macOS systems where Finder is available
- DMG will still be created even if AppleScript styling fails (e.g., in headless runners)