### PR TITLE
Fix DMG mount point parsing and BuildInfo backup location

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,6 @@ let package = Package(
                 .product(name: "MarkdownUI", package: "swift-markdown-ui")
             ],
             path: "Sources/LookMaNoHands",
-            exclude: [
-                "Services/BuildInfo.swift.backup"
-            ],
             resources: [
                 .copy("Resources")
             ],

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -78,13 +78,14 @@ hdiutil create -volname "${APP_NAME}" \
 [ -d "${DMG_TEMP}" ] && rm -rf "${DMG_TEMP}"
 
 # Phase B — Mount, copy background, style via AppleScript
-# Let hdiutil choose the mount point, then parse it from output (avoids
-# quoting pitfalls with space-containing -mountpoint paths on CI runners).
-HDIUTIL_OUT=$(hdiutil attach -readwrite -noverify "${TEMP_DMG}")
-MOUNT_DIR=$(echo "$HDIUTIL_OUT" | tail -1 | sed 's/.*\t//;s/[[:space:]]*$//')
-if [ -z "${MOUNT_DIR}" ] || [ ! -d "${MOUNT_DIR}" ]; then
-    echo "ERROR: Failed to mount DMG (parsed mount point: '${MOUNT_DIR}')"
-    echo "hdiutil output: ${HDIUTIL_OUT}"
+# Use a space-free temp directory as mount point to avoid both:
+#   - fragile hdiutil output parsing (sed tab-splitting fails on macOS BSD sed)
+#   - quoting issues with space-containing -mountpoint paths on CI runners
+MOUNT_DIR=$(mktemp -d)/dmg-mount
+mkdir -p "${MOUNT_DIR}"
+hdiutil attach -readwrite -noverify -mountpoint "${MOUNT_DIR}" "${TEMP_DMG}"
+if [ ! -d "${MOUNT_DIR}" ]; then
+    echo "ERROR: Failed to mount DMG at '${MOUNT_DIR}'"
     rm -f "${TEMP_DMG}"
     exit 1
 fi
@@ -116,9 +117,9 @@ if [ -f "Resources/dmg-background.png" ]; then
 fi
 
 # Style the DMG window with AppleScript (non-fatal — may fail in headless CI).
-# Note: we use `|| true` instead of `if ! osascript <<HEREDOC` because bash 3.x
-# (macOS default) has a known interaction between set -e and heredocs inside `if`
-# conditions that can cause the script to exit despite the guard.
+# Note: we pipe the AppleScript via a variable instead of `if ! osascript <<HEREDOC`
+# because bash 3.x (macOS default) has a known interaction between set -e and
+# heredocs inside `if` conditions that can cause the script to exit despite the guard.
 APPLESCRIPT_CONTENT=$(cat <<APPLESCRIPT_EOF
 tell application "Finder"
     tell disk "${APP_NAME}"

--- a/scripts/inject-build-info.sh
+++ b/scripts/inject-build-info.sh
@@ -24,8 +24,10 @@ COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")
 BUILD_DATE=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
-# Backup the placeholder BuildInfo.swift
-if ! cp "$BUILD_INFO_FILE" "$BUILD_INFO_FILE.backup"; then
+# Backup the placeholder BuildInfo.swift outside Sources/ so SPM doesn't warn
+BUILD_INFO_BACKUP="$REPO_ROOT/.build/BuildInfo.swift.backup"
+mkdir -p "$(dirname "$BUILD_INFO_BACKUP")"
+if ! cp "$BUILD_INFO_FILE" "$BUILD_INFO_BACKUP"; then
     echo "ERROR: Failed to backup BuildInfo.swift" >&2
     return 1
 fi
@@ -33,9 +35,9 @@ fi
 # Set up trap to restore BuildInfo.swift on any exit (success or failure)
 # Chain with any existing EXIT trap to avoid clobbering callers' cleanup logic
 cleanup_build_info() {
-    if [ -f "$BUILD_INFO_FILE.backup" ]; then
+    if [ -f "$BUILD_INFO_BACKUP" ]; then
         echo "🔄 Restoring BuildInfo.swift placeholder..."
-        mv "$BUILD_INFO_FILE.backup" "$BUILD_INFO_FILE"
+        mv "$BUILD_INFO_BACKUP" "$BUILD_INFO_FILE"
     fi
 }
 _existing_exit_trap=$(trap -p EXIT | sed "s/^trap -- '//;s/' EXIT$//")


### PR DESCRIPTION
## Summary

- **Fix DMG mount point parsing**: Replace fragile `sed` tab-splitting of `hdiutil` output with `mktemp -d` based mount point passed via `-mountpoint` flag. The sed approach failed on macOS BSD sed, producing `Hands` instead of `/Volumes/Look Ma No Hands` ([CI failure](https://github.com/qaid/look-ma-no-hands/actions/runs/23205864036/job/67484275797))
- **Move BuildInfo backup outside Sources/**: Place `BuildInfo.swift.backup` in `.build/` instead of alongside the source file, eliminating SPM "unhandled file" warning without needing a Package.swift exclude
- **Fix misleading comment**: Correct comment that claimed `|| true` was used when the code actually pipes AppleScript via a variable

## Test plan

- [ ] CI build passes with DMG creation succeeding
- [ ] BuildInfo.swift.backup no longer triggers SPM warning
- [ ] DMG contains correct app layout and Applications symlink