### PR TITLE
Suppress settings window flash on launch

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -203,15 +203,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// The `Settings` scene creates an `NSWindow` with this identifier automatically.
     private func closeAutoOpenedSettingsWindow() {
         // Synchronous pass: hide immediately to prevent any visible flash
+        var closedSettingsWindowSynchronously = false
         for window in NSApp.windows where window.identifier?.rawValue == "com_apple_SwiftUI_Settings_window" {
             window.orderOut(nil)
             window.close()
+            closedSettingsWindowSynchronously = true
         }
-        // Safety net: async check in case the window is created after this call
+        // Safety net: async check in case the window is created after this call.
+        // Also removes the observer only after confirming the window was handled,
+        // so the observer stays active if the window hasn't appeared yet.
         DispatchQueue.main.async { [weak self] in
+            var closedWindow = false
             for window in NSApp.windows where window.identifier?.rawValue == "com_apple_SwiftUI_Settings_window" {
                 window.orderOut(nil)
                 window.close()
+                closedWindow = true
             }
             // If no tracked windows are visible, reset to accessory mode.
             // The auto-opened Settings window bypasses windowWillClose identity checks
@@ -223,11 +229,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if !hasVisibleTrackedWindow {
                 NSApp.setActivationPolicy(.accessory)
             }
-        }
-        // Remove the observer if still active (no longer needed after explicit close)
-        if let observer = settingsWindowObserver {
-            NotificationCenter.default.removeObserver(observer)
-            settingsWindowObserver = nil
+            // Only remove the observer if we found and closed the window here
+            // or it was already handled by the synchronous pass. The observer
+            // self-removes when it fires, so leaving it active is safe.
+            if closedWindow || closedSettingsWindowSynchronously {
+                if let observer = self?.settingsWindowObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                    self?.settingsWindowObserver = nil
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `applicationWillFinishLaunching` observer that intercepts the auto-opened SwiftUI Settings window via `didBecomeKey` notification and immediately hides it before it renders
- Make `closeAutoOpenedSettingsWindow()` do a synchronous `orderOut`/`close` pass before the existing async safety net
- Prevents the confusing flash of the settings window on fresh install, update, and onboarding flows

Fixes #305

## Test plan
- [ ] Fresh install from DMG: verify no settings window flash during onboarding
- [ ] App update launch with permissions intact: verify no settings window flash
- [ ] App update launch with permissions lost: verify no flash during permissions-only onboarding
- [ ] Open settings from menu bar: verify settings window still works correctly
- [ ] `swift test` passes (116 tests, 0 failures)
- [ ] `swift build -c release` succeeds