### PR TITLE
Fix window appearance inconsistencies between local and notarized builds

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -6,6 +6,8 @@ import AVFoundation
 /// This is where we configure the app to run as a menu bar app without a dock icon
 class AppDelegate: NSObject, NSApplicationDelegate {
 
+    // MARK: - Properties
+
     // Menu bar status item
     private var statusItem: NSStatusItem?
     private var recordingMenuItem: NSMenuItem?
@@ -235,6 +237,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Window Appearance
+
+    /// Returns a concrete NSAppearance when the user has picked Light or Dark,
+    /// or nil to let the window inherit dynamically from the screen/system context.
+    /// Using nil avoids the stale-snapshot race that occurs when reading
+    /// NSApp.effectiveAppearance immediately after setActivationPolicy(.regular).
+    private func resolvedWindowAppearance() -> NSAppearance? {
+        switch Settings.shared.appearanceTheme {
+        case .light:  return NSAppearance(named: .aqua)
+        case .dark:   return NSAppearance(named: .darkAqua)
+        case .system: return nil
+        }
+    }
+
     // MARK: - Onboarding
 
     private func showOnboarding() {
@@ -290,11 +306,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isReleasedWhenClosed = false
         window.level = .normal  // Use normal level so system permission dialogs appear above
 
-        // Explicit appearance to ensure consistency between swift-run and deployed .app bundle.
-        // Without these, the agent→regular activation policy switch can produce muted/default styling.
         window.titlebarSeparatorStyle = .automatic
         window.backgroundColor = .windowBackgroundColor
-        window.appearance = NSApp.effectiveAppearance
+        // Use nil (system) or user-chosen theme — avoids stale effectiveAppearance
+        // snapshot during the accessory→regular activation policy transition.
+        window.appearance = resolvedWindowAppearance()
         NSLog("   ✓ Configured NSWindow")
 
         self.onboardingWindow = window
@@ -302,12 +318,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Bring window to front and activate app
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-
-        // Force window display refresh after activation policy change to ensure
-        // all system colors and materials resolve with the correct appearance.
-        window.invalidateShadow()
-        window.displayIfNeeded()
-        NSLog("   ✓ Made window key and front")
 
         // Ensure window stays on top
         window.orderFrontRegardless()
@@ -366,11 +376,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isReleasedWhenClosed = false
         window.level = .normal  // Use normal level so system permission dialogs appear above
 
-        // Explicit appearance to ensure consistency between swift-run and deployed .app bundle.
-        // Without these, the agent→regular activation policy switch can produce muted/default styling.
         window.titlebarSeparatorStyle = .automatic
         window.backgroundColor = .windowBackgroundColor
-        window.appearance = NSApp.effectiveAppearance
+        window.appearance = resolvedWindowAppearance()
         NSLog("   ✓ Configured NSWindow")
 
         self.onboardingWindow = window
@@ -378,12 +386,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Bring window to front and activate app
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-
-        // Force window display refresh after activation policy change to ensure
-        // all system colors and materials resolve with the correct appearance.
-        window.invalidateShadow()
-        window.displayIfNeeded()
-        NSLog("   ✓ Made window key and front")
 
         // Ensure window stays on top
         window.orderFrontRegardless()
@@ -616,10 +618,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isReleasedWhenClosed = false
         window.delegate = self
 
-        // Explicit appearance to ensure consistency between swift-run and deployed .app bundle
         window.titlebarSeparatorStyle = .automatic
         window.backgroundColor = .windowBackgroundColor
-        window.appearance = NSApp.effectiveAppearance
+        window.appearance = resolvedWindowAppearance()
 
         // Create SwiftUI settings view and wrap it in NSHostingView
         let settingsView = SettingsView(whisperService: whisperService)
@@ -630,8 +631,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        window.invalidateShadow()
-        window.displayIfNeeded()
 
         NSLog("✅ Settings window created and displayed")
     }
@@ -674,13 +673,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.setFrameAutosaveName("MeetingTranscriptionWindow")
         window.delegate = self
 
-        // Explicit appearance to ensure consistency between swift-run and deployed .app bundle.
-        // Without these, the agent→regular activation policy switch can produce muted/default styling.
         window.titlebarSeparatorStyle = .automatic
         window.backgroundColor = .windowBackgroundColor
-        // Inherit the effective system appearance so the window doesn't render with
-        // a stale appearance from the accessory activation policy.
-        window.appearance = NSApp.effectiveAppearance
+        window.appearance = resolvedWindowAppearance()
 
         // Create SwiftUI meeting view and wrap it in NSHostingView
         let meetingView = MeetingView(whisperService: whisperService, recordingIndicator: recordingIndicator, appDelegate: self)
@@ -691,11 +686,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-
-        // Force window display refresh after activation policy change to ensure
-        // all system colors and materials resolve with the correct appearance.
-        window.invalidateShadow()
-        window.displayIfNeeded()
 
         Settings.shared.meetingWindowWasOpen = true
         NSLog("✅ Meeting Transcription window created and displayed")

--- a/Sources/LookMaNoHands/Views/MeetingView.swift
+++ b/Sources/LookMaNoHands/Views/MeetingView.swift
@@ -98,5 +98,7 @@ struct MeetingView: View {
             .tag(MeetingTab.library)
         }
         .frame(minWidth: 700, minHeight: 500)
+        .preferredColorScheme(Settings.shared.appearanceTheme == .light ? .light :
+                              Settings.shared.appearanceTheme == .dark ? .dark : nil)
     }
 }

--- a/Sources/LookMaNoHands/Views/OnboardingView.swift
+++ b/Sources/LookMaNoHands/Views/OnboardingView.swift
@@ -71,10 +71,12 @@ struct OnboardingView: View {
             if !onboardingState.isPermissionsOnlyFlow {
                 ProgressIndicatorView(currentStep: onboardingState.currentStep)
                     .frame(maxWidth: .infinity)
-                    .background(Color(NSColor.windowBackgroundColor))
+                    .background(.background)
             }
         }
         .frame(width: 600, height: 520)
+        .preferredColorScheme(Settings.shared.appearanceTheme == .light ? .light :
+                              Settings.shared.appearanceTheme == .dark ? .dark : nil)
         .onAppear {
             // If starting at permissions, configure the state accordingly
             if startAtPermissions {

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -90,6 +90,8 @@ struct SettingsView: View {
         .toolbar(.hidden)
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 750, minHeight: 450)
+        .preferredColorScheme(settings.appearanceTheme == .light ? .light :
+                              settings.appearanceTheme == .dark ? .dark : nil)
         .onAppear {
             checkPermissions()
             checkWhisperModelStatus()

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -53,7 +53,7 @@ if [ -n "${DEVELOPER_ID_APPLICATION}" ]; then
     echo "✅ Developer ID signature verified"
 else
     echo "No DEVELOPER_ID_APPLICATION set — using ad-hoc signing"
-    codesign --force --sign - "${APP_PATH}"
+    codesign --force --sign - --entitlements "${ENTITLEMENTS}" "${APP_PATH}"
 fi
 
 echo "Creating DMG..."


### PR DESCRIPTION
## Summary

Resolves visual presentation differences between local builds (deploy.sh) and CI/CD builds (notarized DMG) caused by a race condition where `NSApp.effectiveAppearance` is captured during the `.accessory` → `.regular` activation policy transition.

## Root Causes

1. **Stale appearance snapshot**: Reading `NSApp.effectiveAppearance` immediately after `setActivationPolicy(.regular)` returns the old context because the Window Server hasn't propagated the update yet. Since it's pinned non-nil, the window never self-corrects.
2. **Missing entitlements in ad-hoc fallback**: The `create-dmg.sh` script's ad-hoc signing path was missing the `--entitlements` flag, breaking microphone and network access on ad-hoc DMG builds.
3. **SwiftUI color scheme not driven by user theme**: Views depended entirely on the (stale) NSWindow appearance instead of `Settings.shared.appearanceTheme`.

## Changes

- Add `resolvedWindowAppearance()` helper that returns `nil` for system theme (allowing dynamic inheritance) or explicit `.aqua`/`.darkAqua` for user-chosen light/dark modes
- Replace all `NSApp.effectiveAppearance` snapshots with the helper
- Remove ineffective `invalidateShadow()` + `displayIfNeeded()` calls
- Add `.preferredColorScheme` modifier to OnboardingView, SettingsView, and MeetingView
- Fix `create-dmg.sh` ad-hoc fallback to include `--entitlements` flag
- Replace `Color(NSColor.windowBackgroundColor)` with `.background` for dynamic resolution

## Testing

- Release build compiles successfully
- All 116 existing tests pass
- Visual consistency verified across local deploy, ad-hoc DMG, and notarized DMG paths