### PR TITLE
Fix visual parity: upgrade CI runners to macOS 26 (Tahoe)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
   analyze:
     name: Analyze Swift Code
     if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-14
+    runs-on: macos-26
     env:
       HAS_SIGNING_CERT: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION != '' }}
       HAS_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
   verify-dependencies:
     name: Verify Package.resolved Integrity
     if: github.event_name == 'push' || github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
   build-verification:
     name: Verify Clean Build
     if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || startsWith(github.ref, 'refs/heads/security-')
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
   entitlements-check:
     name: Verify App Entitlements
     if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || startsWith(github.ref, 'refs/heads/security-')
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Run Tests
     if: github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -41,6 +41,8 @@
 	<string>Look Ma No Hands needs to control other applications to insert transcribed text.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026. All rights reserved.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -59,6 +59,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Application Lifecycle
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+        // Set app-level appearance before any windows are created so all windows
+        // (including the auto-created SwiftUI Settings window) inherit the correct theme.
+        NSApp.appearance = AppearanceResolver.resolved()
+
         // Install an observer to intercept the SwiftUI Settings window before it becomes visible.
         // The SwiftUI `Settings` scene auto-creates an NSWindow on first launch; this observer
         // catches it via didBecomeKey and orderOut immediately to prevent a visible flash.


### PR DESCRIPTION
## Summary

- Upgrade all CI workflow runners from `macos-14` (Sonoma) to `macos-26` (Tahoe) so release builds use the same macOS SDK as local development
- Add `NSPrincipalClass` to Info.plist for correct modern Cocoa app initialization
- Set `NSApp.appearance` early in `applicationWillFinishLaunching` for correct appearance inheritance

## Root cause

All CI workflows were building on `macos-14` (Sonoma, macOS 14 SDK) while the development machine runs macOS Tahoe 26.3 with the macOS 26 SDK. Binaries compiled against the macOS 14 SDK render in compatibility mode on Tahoe — they don't get native Tahoe window chrome, materials, or color system. This caused the visual differences between local and released builds.

Previous PRs (#292, #308, #309, #310) attempted to fix NSAppearance race conditions, which was not the actual problem.

The `macos-26` GitHub Actions runner has been GA since February 26, 2026.

## Files changed

- `.github/workflows/release.yml` — `macos-14` → `macos-26`
- `.github/workflows/test-coverage.yml` — `macos-14` → `macos-26`
- `.github/workflows/codeql.yml` — `macos-14` → `macos-26`
- `.github/workflows/security.yml` — all `macos-14` jobs → `macos-26` (ubuntu jobs unchanged)
- `Resources/Info.plist` — add `NSPrincipalClass` key
- `Sources/LookMaNoHands/App/AppDelegate.swift` — set `NSApp.appearance` in `applicationWillFinishLaunching`

Closes #316
Closes #288

## Test plan

- [ ] CI workflows run successfully on `macos-26` runner
- [ ] Create test release tag to verify DMG is built with Tahoe SDK
- [ ] Install CI-built DMG on macOS Tahoe and compare visually with `deploy.sh` build
- [ ] Verify both light and dark mode across all window types (settings, meeting, onboarding, overlays)