### PR TITLE
Upgrade CI runners from macos-14 to macos-15 for Swift 6.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
   analyze:
     name: Analyze Swift Code
     if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       HAS_SIGNING_CERT: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION != '' }}
       HAS_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
   verify-dependencies:
     name: Verify Package.resolved Integrity
     if: github.event_name == 'push' || github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
   build-verification:
     name: Verify Clean Build
     if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || startsWith(github.ref, 'refs/heads/security-')
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
   entitlements-check:
     name: Verify App Entitlements
     if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || startsWith(github.ref, 'refs/heads/security-')
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     name: Run Tests
     if: github.event.review.state == 'approved'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Upgrades all GitHub Actions macOS runners from `macos-14` to `macos-15`
- `macos-14` ships with Swift 5.10, which cannot build `swift-tools-version: 6.0` (merged in #318)
- `macos-15` includes Swift 6.0 by default

Affected workflows: `security.yml`, `test-coverage.yml`, `codeql.yml`, `release.yml`

## Test plan

- [ ] Verify `security.yml` verify-dependencies job passes on `macos-15`
- [ ] Verify `test-coverage.yml` tests run successfully
- [ ] Verify `codeql.yml` analysis completes
- [ ] Verify `release.yml` builds correctly (tested on next tag push)