### PR TITLE
Trigger model warm-up on dictation model switch

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -443,6 +443,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             object: nil
         )
 
+        // Listen for whisper model changes from Settings
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(whisperModelDidChange(_:)),
+            name: .whisperModelChanged,
+            object: nil
+        )
+
         // Check for updates if enabled (silent, non-blocking)
         if Settings.shared.checkForUpdatesOnLaunch {
             Task {
@@ -1004,6 +1012,48 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         hotkeyToggleSplash.show(isEnabled: enabled)
     }
 
+    /// Handle whisper model changes from Settings
+    @objc private func whisperModelDidChange(_ notification: Notification) {
+        guard let modelName = notification.userInfo?["model"] as? String else { return }
+
+        // Skip if this model is already loaded
+        guard whisperService.loadedModelName != modelName else {
+            NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+            return
+        }
+
+        updateMenuBarStatus("Loading model...")
+
+        Task {
+            do {
+                try await whisperService.loadModel(named: modelName)
+                NSLog("✅ Whisper model '\(modelName)' loaded after settings change")
+
+                await MainActor.run {
+                    updateMenuBarStatus("Warming up...")
+                }
+
+                await whisperService.warmUpNeuralEngine()
+
+                await MainActor.run {
+                    updateMenuBarStatus("Ready")
+                }
+                NSLog("✅ Neural Engine warm-up complete for '\(modelName)'")
+            } catch {
+                NSLog("❌ Failed to load model '\(modelName)' after settings change: \(error.localizedDescription)")
+                await MainActor.run {
+                    updateMenuBarStatus("Model load failed")
+                    showAlert(
+                        title: "Model Load Failed",
+                        message: "Failed to load the \(modelName) model: \(error.localizedDescription)"
+                    )
+                }
+            }
+
+            NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+        }
+    }
+
     // MARK: - Contextual Prompt Building
 
     /// Build an initial_prompt for Whisper based on the active app and field context
@@ -1187,11 +1237,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         }
 
         // Check if Whisper model is ready
-        if !whisperService.isModelLoaded {
+        if !whisperService.isModelLoaded || whisperService.isModelLoading || whisperService.isWarmingUp {
             if whisperService.isModelLoading {
                 showAlert(
                     title: "Model Loading",
                     message: "The Whisper model is still loading. Please wait a moment and try again."
+                )
+            } else if whisperService.isWarmingUp {
+                showAlert(
+                    title: "Warming Up",
+                    message: "The Neural Engine is warming up for the new model. Please wait a moment and try again."
                 )
             } else {
                 showAlert(
@@ -1417,6 +1472,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
                 await MainActor.run {
                     autoreleasepool {
+                        // Restore focus to the window/field that was active when recording started
+                        if let targetElement = self.focusedElementBeforeRecording {
+                            self.restoreFocus(to: targetElement)
+                            Thread.sleep(forTimeInterval: 0.05)
+                        }
+
                         self.textInsertionService.insertText(formattedText)
                         self.transcriptionState.setFormattedText(formattedText)
                         self.transcriptionState.completeProcessing()

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -25,6 +25,8 @@ extension Notification.Name {
     static let hotkeyConfigurationChanged = Notification.Name("hotkeyConfigurationChanged")
     static let hotkeyEnabledChanged = Notification.Name("hotkeyEnabledChanged")
     static let toggleShortcutChanged = Notification.Name("toggleShortcutChanged")
+    static let whisperModelChanged = Notification.Name("whisperModelChanged")
+    static let whisperModelReady = Notification.Name("whisperModelReady")
 }
 
 /// Available Whisper model sizes (WhisperKit format)

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -20,6 +20,9 @@ class WhisperService: @unchecked Sendable {
     /// Whether model is currently loading
     private(set) var isModelLoading = false
 
+    /// Whether the Neural Engine is currently warming up
+    private(set) var isWarmingUp = false
+
     /// Name of the currently loaded model (e.g., "base", "large-v3-turbo")
     private(set) var loadedModelName: String?
 
@@ -204,6 +207,9 @@ class WhisperService: @unchecked Sendable {
     ///
     /// Failures are logged but don't block onboarding (warm-up is an optimization).
     func warmUpNeuralEngine() async {
+        isWarmingUp = true
+        defer { isWarmingUp = false }
+
         Logger.shared.info("🔥 Warming up Neural Engine...", category: .whisper)
         let startTime = Date()
 

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
     @State private var ollamaStatus: ConnectionState = .unknown
     @State private var availableOllamaModels: [String] = []
     @State private var isDownloadingModel = false
+    @State private var isModelReloading = false
     @State private var modelDownloadError: String?
     @State private var modelAvailability: [WhisperModel: Bool] = [:]
 
@@ -103,6 +104,10 @@ struct SettingsView: View {
         }
         .onDisappear {
             stopPermissionPolling()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .whisperModelReady)) { _ in
+            isModelReloading = false
+            checkWhisperModelStatus()
         }
     }
 
@@ -1699,11 +1704,21 @@ struct SettingsView: View {
         // Clear any previous error
         modelDownloadError = nil
 
-        // If the model is already loaded or exists on disk, no download needed
         let isLoaded = whisperService.loadedModelName == newModel.rawValue
+        if isLoaded { return }
+
         let existsOnDisk = WhisperService.modelExists(named: newModel.rawValue)
 
-        if !isLoaded && !existsOnDisk {
+        if existsOnDisk {
+            // Model exists on disk but isn't loaded — notify AppDelegate to load + warm up
+            isModelReloading = true
+            NotificationCenter.default.post(
+                name: .whisperModelChanged,
+                object: nil,
+                userInfo: ["model": newModel.rawValue]
+            )
+        } else {
+            // Download first, then notify
             Task {
                 await downloadModel(newModel)
             }
@@ -1720,13 +1735,18 @@ struct SettingsView: View {
         do {
             try await WhisperService.downloadModel(named: model.rawValue)
 
-            // Download successful
+            // Download successful — notify AppDelegate to load + warm up
             DispatchQueue.main.async {
                 self.isDownloadingModel = false
+                self.isModelReloading = true
                 self.modelAvailability[model] = true
                 print("SettingsView: Model \(model.rawValue) downloaded successfully")
 
-                // TODO: Notify AppDelegate to reload the model
+                NotificationCenter.default.post(
+                    name: .whisperModelChanged,
+                    object: nil,
+                    userInfo: ["model": model.rawValue]
+                )
             }
 
         } catch {
@@ -1743,6 +1763,8 @@ struct SettingsView: View {
     private var modelStatusColor: Color {
         if isDownloadingModel {
             return .yellow
+        } else if isModelReloading {
+            return .blue
         } else if let isAvailable = modelAvailability[settings.whisperModel] {
             return isAvailable ? .green : .orange
         } else {
@@ -1754,6 +1776,8 @@ struct SettingsView: View {
     private var modelStatusText: String {
         if isDownloadingModel {
             return "Downloading..."
+        } else if isModelReloading {
+            return whisperService.isWarmingUp ? "Warming up..." : "Loading..."
         } else if let isAvailable = modelAvailability[settings.whisperModel] {
             return isAvailable ? "Downloaded" : "Not downloaded"
         } else {


### PR DESCRIPTION
## Summary

When users switch whisper models in Settings, the app now immediately loads the new model and warms up the Neural Engine instead of waiting for first use. This eliminates 10+ second cold-start latency on first dictation after a model change. Settings UI shows "Loading..." and "Warming up..." feedback during the process, and dictation attempts during warm-up are blocked with an informative alert.

Also fixes text insertion to target the window that was active when recording started, not whichever window happens to be focused when transcription completes.

## Changes

- Add `isWarmingUp` property to WhisperService and track warm-up state
- Post `.whisperModelChanged` notification from SettingsView when model is selected
- AppDelegate observes model changes, loads the model, and warms up the Neural Engine
- Block dictation with "Warming up..." alert until Neural Engine is ready
- Restore focus to original window before text insertion to prevent pasting into wrong app
- Add `.whisperModelReady` notification so Settings UI can update status display

Closes #317