### PR TITLE
Fix security workflow WhisperKit revision for 0.17.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Verify WhisperKit revision
         run: |
-          EXPECTED_REV="3900754c847a86f4b03df7e0a772933613d79c67"
+          EXPECTED_REV="26577ce3017aae8c9edfd9a0dd17851bd248c731"
           ACTUAL_REV=$(grep -A 5 '"identity" : "whisperkit"' Package.resolved | grep '"revision"' | cut -d'"' -f4)
 
           if [ "$ACTUAL_REV" != "$EXPECTED_REV" ]; then


### PR DESCRIPTION
## Summary

- Update the hardcoded WhisperKit revision in the security workflow's `Package.resolved` integrity check to match the 0.17.0 revision merged in #325

## Test plan

- [x] CI security workflow should pass with the updated revision