### PR TITLE
Bump version to 1.5.1 (build 18)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary
- Bumps version from 1.5.0 to 1.5.1 (build 17 → 18) in Info.plist
- Prepares for release via `v1.5.1` tag

## Test plan
- [ ] Verify Info.plist has correct version and build number
- [ ] After merge, tag `v1.5.1` triggers release workflow