### PR TITLE
Fix cursor insertion point after recording

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
     // Focused element before recording started (for restoring focus on cancel)
     private var focusedElementBeforeRecording: AXUIElement?
+    private var cursorSnapshotBeforeRecording: CursorSnapshot?
 
     // Popover for menu bar content (alternative to dropdown menu)
     private var popover: NSPopover?
@@ -1171,10 +1172,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         // Update state to idle (skips processing)
         transcriptionState.cancelRecording()
 
-        // Restore focus to the original field
+        // Restore focus and cursor position to the original field
         if let focusedElement = focusedElementBeforeRecording {
             restoreFocus(to: focusedElement)
+            Thread.sleep(forTimeInterval: 0.05)
+            if let snapshot = cursorSnapshotBeforeRecording {
+                textInsertionService.restoreCursorPosition(snapshot)
+            }
             focusedElementBeforeRecording = nil
+            cursorSnapshotBeforeRecording = nil
         }
 
         // Update UI
@@ -1261,8 +1267,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             return
         }
 
-        // Capture the focused element BEFORE showing indicator
+        // Capture the focused element and cursor position BEFORE showing indicator
         focusedElementBeforeRecording = textInsertionService.getFocusedElement()
+        if let element = focusedElementBeforeRecording {
+            cursorSnapshotBeforeRecording = textInsertionService.captureCursorPosition(for: element)
+        }
 
         // Capture field context NOW, before any previous transcription could contaminate it
         capturedInitialPrompt = buildInitialPrompt()
@@ -1480,6 +1489,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                         if let targetElement = self.focusedElementBeforeRecording {
                             self.restoreFocus(to: targetElement)
                             Thread.sleep(forTimeInterval: 0.05)
+                            // Restore cursor position so Cmd+V pastes at the right location
+                            if let snapshot = self.cursorSnapshotBeforeRecording {
+                                self.textInsertionService.restoreCursorPosition(snapshot)
+                                Thread.sleep(forTimeInterval: 0.05)
+                            }
                         }
 
                         self.textInsertionService.insertText(formattedText)
@@ -1488,6 +1502,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
                         // Clear the stored focus since we successfully completed
                         self.focusedElementBeforeRecording = nil
+                        self.cursorSnapshotBeforeRecording = nil
                     }
                 }
                 let insertTime = Date().timeIntervalSince(insertStart)

--- a/Sources/LookMaNoHands/Services/TextInsertionService.swift
+++ b/Sources/LookMaNoHands/Services/TextInsertionService.swift
@@ -10,6 +10,13 @@ private struct AXTextFieldState {
     let selectionLength: Int // UTF-16 offset
 }
 
+/// Snapshot of cursor position within an AX element, for later restoration
+struct CursorSnapshot {
+    let element: AXUIElement
+    let cursorLocation: Int  // UTF-16 offset
+    let selectionLength: Int // UTF-16 offset
+}
+
 /// Service for inserting text into the currently focused text field
 /// Uses multiple strategies to maximize compatibility across applications
 class TextInsertionService: @unchecked Sendable {
@@ -142,7 +149,39 @@ class TextInsertionService: @unchecked Sendable {
         
         return (element as! AXUIElement)
     }
-    
+
+    /// Capture the cursor position of a given AX element for later restoration
+    func captureCursorPosition(for element: AXUIElement) -> CursorSnapshot? {
+        var selectedRange: CFTypeRef?
+        let rangeResult = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &selectedRange
+        )
+
+        guard rangeResult == .success, let rangeValue = selectedRange else {
+            return nil
+        }
+
+        var range = CFRange()
+        AXValueGetValue(rangeValue as! AXValue, .cfRange, &range)
+
+        return CursorSnapshot(
+            element: element,
+            cursorLocation: range.location,
+            selectionLength: range.length
+        )
+    }
+
+    /// Restore a previously captured cursor position
+    func restoreCursorPosition(_ snapshot: CursorSnapshot) {
+        setCursorPosition(
+            element: snapshot.element,
+            location: snapshot.cursorLocation,
+            length: snapshot.selectionLength
+        )
+    }
+
     /// Insert text at the current selection point using captured AX state
     /// Uses UTF-16 offsets (NSString convention) to match AX API behavior
     private func insertAtSelection(_ state: AXTextFieldState, text: String) -> Bool {
@@ -197,8 +236,8 @@ class TextInsertionService: @unchecked Sendable {
     }
 
     /// Helper to set cursor position with retry logic
-    private func setCursorPosition(element: AXUIElement, location: Int, attempt: Int = 1) {
-        var newRange = CFRange(location: location, length: 0)
+    private func setCursorPosition(element: AXUIElement, location: Int, length: Int = 0, attempt: Int = 1) {
+        var newRange = CFRange(location: location, length: length)
 
         guard let rangeValue = AXValueCreate(.cfRange, &newRange) else {
             print("TextInsertionService: Failed to create CFRange for cursor")
@@ -220,7 +259,7 @@ class TextInsertionService: @unchecked Sendable {
 
             nonisolated(unsafe) let capturedElement = element
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { @Sendable [self] in
-                self.setCursorPosition(element: capturedElement, location: location, attempt: attempt + 1)
+                self.setCursorPosition(element: capturedElement, location: location, length: length, attempt: attempt + 1)
             }
         } else {
             print("TextInsertionService: ❌ Cursor positioning failed after \(attempt) attempts")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -131,21 +131,18 @@ fi
 # App defaults (conditional based on flag)
 if [ "$RESET_DEFAULTS" = true ]; then
     echo "🧹 Resetting app preferences (preserving vocabulary & user data)..."
-    # Delete all preference keys EXCEPT user data worth preserving
+    # Delete only ephemeral/state keys that should be reset between deploys.
+    # All user-configured settings (hotkeys, vocabulary, models, folder selections,
+    # appearance, meeting prompts, etc.) are preserved by default.
     # Note: vocabulary and toggleHotkey now live in Application Support files,
-    # but legacy UserDefaults keys (customVocabulary, toggleHotkeyShortcut) must
-    # also be preserved for users who haven't yet launched the app to trigger migration.
-    # hasCompletedOnboarding is preserved to avoid forcing full re-onboarding.
-    PRESERVE_KEYS="hasCompletedOnboarding|meetingTypePrompts|customVocabulary|toggleHotkeyShortcut"
-    ALL_KEYS=$(defaults read com.lookmanohands.app 2>/dev/null | grep -oE '^\s{4}[a-zA-Z][a-zA-Z0-9]*' | sed 's/^ *//' || true)
-    for key in $ALL_KEYS; do
-        if ! echo "$key" | grep -qE "^($PRESERVE_KEYS)$"; then
-            defaults delete com.lookmanohands.app "$key" 2>/dev/null || true
-        fi
+    # but legacy UserDefaults keys (customVocabulary, toggleHotkeyShortcut) are
+    # also preserved for users who haven't yet launched the app to trigger migration.
+    RESET_KEYS="pendingScreenRecordingGrant meetingWindowWasOpen lastUpdateCheckDate skippedUpdateSHA"
+    for key in $RESET_KEYS; do
+        defaults delete com.lookmanohands.app "$key" 2>/dev/null || true
     done
-    defaults write com.lookmanohands.app triggerKey "Right Option"
-    echo "   ✅ App preferences reset to factory settings"
-    echo "   ℹ️  Vocabulary, custom prompts, and onboarding state preserved"
+    echo "   ✅ Ephemeral state reset"
+    echo "   ℹ️  All user settings preserved (vocabulary, hotkeys, folders, models, prompts)"
 else
     echo "ℹ️  Preserving existing app defaults"
     echo "   (use './deploy.sh --reset-defaults' to reset)"


### PR DESCRIPTION
## Summary

- Captures cursor position (AX selected text range) before recording starts, alongside the existing focused element snapshot
- Restores cursor position before text insertion and on cancel, ensuring dictated text pastes at the original location even after focus shifts to the recording indicator and back
- Adds 50ms delays between focus restoration and cursor restoration to allow AX API operations to be processed by the target app
- Adds `CursorSnapshot` struct and `captureCursorPosition`/`restoreCursorPosition` methods to `TextInsertionService`
- Extends `setCursorPosition` to support restoring selection length (not just cursor location)
- Fixes deploy script `--reset-defaults` to only delete ephemeral state keys instead of wiping all keys except a small preserve list, which was deleting hotkeys, folder selections, model preferences, and appearance settings

## Test plan

- [ ] Start dictation in the middle of existing text in a text field, verify transcribed text is inserted at the original cursor position
- [ ] Cancel recording mid-dictation, verify cursor returns to original position
- [ ] Test in multiple apps (TextEdit, Notes, Safari address bar, Slack) to verify cross-app compatibility
- [ ] Test with text selected before recording, verify selection is restored on cancel
- [ ] Run `./scripts/deploy.sh --reset-defaults` and verify vocabulary, hotkeys, folder selections, and model preferences are preserved