### PR TITLE
Show processing indicator for longer dictation captures

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.3</string>
+	<string>1.5.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
     // UI
     private let recordingIndicator = RecordingIndicatorWindowController()
+    private var pendingProcessingIndicator: DispatchWorkItem?
     private let launchSplash = LaunchSplashWindowController()
     private let hotkeyToggleSplash = HotkeyToggleSplashWindowController()
 
@@ -1424,11 +1425,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         transcriptionState.stopRecording()
         updateMenuBarIcon(isRecording: false)
 
-        // DESIGN: No processing indicator is shown after recording stops.
-        // Hide the recording indicator immediately and process in the background.
-        // The transcribed text appears directly - no spinner, shimmer, or progress bar.
-        // This makes dictation feel instant. The Neural Engine warm-up happens during onboarding.
+        // DESIGN: Recording indicator hides immediately when recording stops.
+        // A processing indicator appears after 500ms if transcription is still running.
+        // This makes short dictations feel instant while giving feedback for longer ones.
         recordingIndicator.hide()
+
+        // Schedule processing indicator to appear after 500ms (avoids flash for fast transcriptions)
+        pendingProcessingIndicator?.cancel()
+        let processingWorkItem = DispatchWorkItem { [weak self] in
+            self?.recordingIndicator.showProcessing()
+        }
+        pendingProcessingIndicator = processingWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: processingWorkItem)
 
         // Resume system media if we paused it
         if Settings.shared.pauseMediaDuringDictation {
@@ -1496,6 +1504,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                             }
                         }
 
+                        self.pendingProcessingIndicator?.cancel()
+                        self.pendingProcessingIndicator = nil
+                        self.recordingIndicator.hideProcessing()
+
                         self.textInsertionService.insertText(formattedText)
                         self.transcriptionState.setFormattedText(formattedText)
                         self.transcriptionState.completeProcessing()
@@ -1516,6 +1528,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 Logger.shared.error("❌ Processing failed after \(String(format: "%.2f", failTime))s: \(error.localizedDescription)", category: .transcription)
 
                 await MainActor.run {
+                    self.pendingProcessingIndicator?.cancel()
+                    self.pendingProcessingIndicator = nil
+                    self.recordingIndicator.hideProcessing()
+
                     self.transcriptionState.setError("Processing failed: \(error.localizedDescription)")
                     // Auto-recover from error state after 3 seconds
                     Task { @MainActor in

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -153,6 +153,7 @@ struct RecordingIndicator: View {
     @ObservedObject var state: RecordingIndicatorState
     @ObservedObject private var settings = Settings.shared
     @Environment(\.colorScheme) var colorScheme
+    @State private var processingPulse = false
 
     /// Compute the effective color scheme based on user's theme preference
     private var effectiveColorScheme: ColorScheme? {
@@ -169,12 +170,21 @@ struct RecordingIndicator: View {
     var body: some View {
         HStack(spacing: 10) {
             if state.isProcessing {
-                ProgressView()
-                    .controlSize(.small)
-                    .scaleEffect(0.8)
+                // Pulsing blue dot
+                Circle()
+                    .fill(Color.blue)
+                    .frame(width: 10, height: 10)
+                    .shadow(color: Color.blue.opacity(0.4), radius: 4, x: 0, y: 0)
+                    .opacity(processingPulse ? 0.4 : 1.0)
+                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: processingPulse)
+                    .onAppear { processingPulse = true }
+                    .onDisappear { processingPulse = false }
+
+                // Processing text in place of waveform (same width to preserve window size)
                 Text("Transcribing...")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.secondary)
+                    .frame(width: 260, height: 34)
             } else {
                 // Static recording dot (no pulsing)
                 Circle()

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -168,14 +168,23 @@ struct RecordingIndicator: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            // Static recording dot (no pulsing)
-            Circle()
-                .fill(Color(red: 1.0, green: 0.23, blue: 0.19))
-                .frame(width: 10, height: 10)
-                .shadow(color: Color(red: 1.0, green: 0.23, blue: 0.19).opacity(0.4), radius: 4, x: 0, y: 0)
+            if state.isProcessing {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.8)
+                Text("Transcribing...")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            } else {
+                // Static recording dot (no pulsing)
+                Circle()
+                    .fill(Color(red: 1.0, green: 0.23, blue: 0.19))
+                    .frame(width: 10, height: 10)
+                    .shadow(color: Color(red: 1.0, green: 0.23, blue: 0.19).opacity(0.4), radius: 4, x: 0, y: 0)
 
-            // Smooth waveform line
-            WaveformLineView(frequencyBands: $state.frequencyBands, width: 260, height: 34)
+                // Smooth waveform line
+                WaveformLineView(frequencyBands: $state.frequencyBands, width: 260, height: 34)
+            }
         }
         .padding(.leading, 14)
         .padding(.trailing, 12)
@@ -230,6 +239,7 @@ struct RecordingIndicatorPreview: View {
 /// Observable state for the recording indicator
 class RecordingIndicatorState: ObservableObject, @unchecked Sendable {
     @Published var frequencyBands: [Float] = Array(repeating: 0.0, count: 40)
+    @Published var isProcessing: Bool = false
 
     // Exponential smoothing for fluid animation
     func updateFrequencyBands(_ newBands: [Float]) {
@@ -404,9 +414,33 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
         window.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
+    /// Show the processing indicator (reuses existing window at same position)
+    func showProcessing() {
+        guard let window = window else { return }
+
+        state.isProcessing = true
+
+        // Window position is preserved from recording — just make it visible
+        window.orderFront(nil)
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            window.animator().alphaValue = 1.0
+        }
+    }
+
+    /// Hide the processing indicator
+    func hideProcessing() {
+        state.isProcessing = false
+        hide()
+    }
+
     /// Show the recording indicator
     func show() {
         guard let window = window else { return }
+
+        // Ensure we're in recording mode (not processing)
+        state.isProcessing = false
 
         // Get user's position preference
         let position = Settings.shared.indicatorPosition

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -145,8 +145,8 @@ struct WaveformLineView: View {
     }
 }
 
-/// Floating window that appears during recording to show the user that audio is being captured
-/// Shows a recording dot + smooth waveform line at the cursor position
+/// Floating window that appears during dictation to show recording and processing states
+/// Recording: red dot + smooth waveform line | Processing: pulsing blue dot + "Transcribing..." text
 /// IMPORTANT: Only shown in dictation mode, NOT in meeting transcription mode
 struct RecordingIndicator: View {
 
@@ -430,13 +430,9 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
 
         state.isProcessing = true
 
-        // Window position is preserved from recording — just make it visible
+        // Cancel any in-progress hide animation before showing
+        window.animator().alphaValue = 1.0
         window.orderFront(nil)
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.15
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            window.animator().alphaValue = 1.0
-        }
     }
 
     /// Hide the processing indicator


### PR DESCRIPTION
## Summary

When dictation recording stops, the recording indicator hides immediately and transcription runs silently. For longer captures (10-30s+ audio), this creates a gap where nothing visually happens, making it look like the dictation failed before text suddenly appears.

This adds a "Transcribing..." processing indicator with a native spinner that appears after a 500ms delay threshold — short dictations still feel instant, while longer ones get visual feedback that processing is underway.

Closes #334