### PR TITLE
Optimize transcription pipeline with vDSP and explicit compute units

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.4</string>
+	<string>1.5.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/Services/AudioRecorder.swift
+++ b/Sources/LookMaNoHands/Services/AudioRecorder.swift
@@ -215,20 +215,24 @@ class AudioRecorder: @unchecked Sendable {
 
         let frameCount = Int(buffer.frameLength)
         let channelCount = Int(buffer.format.channelCount)
+        let length = vDSP_Length(frameCount)
 
-        // Pre-allocate and convert to mono first
-        var samples = [Float]()
-        samples.reserveCapacity(frameCount)
-
-        for frame in 0..<frameCount {
-            var sample: Float = 0
-
-            // Average all channels to mono
-            for channel in 0..<channelCount {
-                sample += channelData[channel][frame]
+        // Convert to mono using vectorized operations
+        var samples: [Float]
+        if channelCount == 1 {
+            samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+        } else if channelCount == 2 {
+            samples = [Float](repeating: 0, count: frameCount)
+            vDSP_vadd(channelData[0], 1, channelData[1], 1, &samples, 1, length)
+            var half: Float = 0.5
+            vDSP_vsmul(samples, 1, &half, &samples, 1, length)
+        } else {
+            samples = Array(UnsafeBufferPointer(start: channelData[0], count: frameCount))
+            for ch in 1..<channelCount {
+                vDSP_vadd(samples, 1, channelData[ch], 1, &samples, 1, length)
             }
-            sample /= Float(channelCount)
-            samples.append(sample)
+            var scale = 1.0 / Float(channelCount)
+            vDSP_vsmul(samples, 1, &scale, &samples, 1, length)
         }
 
         // Thread-safe append to buffer
@@ -237,28 +241,39 @@ class AudioRecorder: @unchecked Sendable {
         }
     }
 
-    /// Resample audio to 16kHz using Accelerate framework
+    /// Resample audio to 16kHz using vectorized vDSP linear interpolation
     private func resampleToTarget(_ samples: [Float]) -> [Float] {
         guard !samples.isEmpty else { return samples }
 
         let inputLength = samples.count
         let ratio = targetSampleRate / inputSampleRate
         let outputLength = Int(Double(inputLength) * ratio)
+        guard outputLength > 0 else { return [] }
+
+        // Build fractional index ramp: [0, 1/ratio, 2/ratio, ...]
+        // vDSP_vlint interprets each value as: integer part = base index, fractional part = blend weight
+        var indices = [Float](repeating: 0, count: outputLength)
+        var start: Float = 0.0
+        var step = Float(1.0 / ratio)
+        vDSP_vramp(&start, &step, &indices, 1, vDSP_Length(outputLength))
+
+        // Clamp to valid range — vDSP_vlint reads index[i] and index[i]+1
+        var maxIndex = Float(inputLength - 2)
+        var zero: Float = 0.0
+        vDSP_vclip(indices, 1, &zero, &maxIndex, &indices, 1, vDSP_Length(outputLength))
 
         var output = [Float](repeating: 0, count: outputLength)
 
-        // Use vDSP for high-quality linear interpolation
         samples.withUnsafeBufferPointer { inputPtr in
-            output.withUnsafeMutableBufferPointer { outputPtr in
-                for i in 0..<outputLength {
-                    let inputIndex = Double(i) / ratio
-                    let lowerIndex = Int(inputIndex)
-                    let upperIndex = min(lowerIndex + 1, inputLength - 1)
-                    let fraction = Float(inputIndex - Double(lowerIndex))
-
-                    outputPtr[i] = inputPtr[lowerIndex] * (1 - fraction) + inputPtr[upperIndex] * fraction
-                }
-            }
+            vDSP_vlint(
+                inputPtr.baseAddress!,
+                indices,
+                1,
+                &output,
+                1,
+                vDSP_Length(outputLength),
+                vDSP_Length(inputLength)
+            )
         }
 
         return output
@@ -268,18 +283,20 @@ class AudioRecorder: @unchecked Sendable {
     private func normalizeAudio(_ samples: [Float]) -> [Float] {
         guard !samples.isEmpty else { return samples }
 
-        var normalized = samples
-
         // Find the peak amplitude
         var maxAmplitude: Float = 0
         vDSP_maxmgv(samples, 1, &maxAmplitude, vDSP_Length(samples.count))
 
-        // Normalize to 0.9 to prevent clipping while maximizing volume
-        if maxAmplitude > 0 {
-            var scaleFactor = 0.9 / maxAmplitude
-            vDSP_vsmul(samples, 1, &scaleFactor, &normalized, 1, vDSP_Length(samples.count))
-            print("AudioRecorder: Normalized audio (peak: \(maxAmplitude) → 0.9)")
+        // Skip normalization if peak is already in acceptable range for Whisper
+        guard maxAmplitude > 0, maxAmplitude < 0.7 || maxAmplitude > 1.0 else {
+            return samples
         }
+
+        // Normalize to 0.9 to prevent clipping while maximizing volume
+        var normalized = samples
+        var scaleFactor = 0.9 / maxAmplitude
+        vDSP_vsmul(samples, 1, &scaleFactor, &normalized, 1, vDSP_Length(samples.count))
+        print("AudioRecorder: Normalized audio (peak: \(maxAmplitude) → 0.9)")
 
         return normalized
     }

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -1,3 +1,4 @@
+import CoreML
 import Foundation
 import WhisperKit
 
@@ -29,6 +30,9 @@ class WhisperService: @unchecked Sendable {
     /// Serializes transcription calls (shared between dictation and meeting mode)
     /// Uses an actor-based semaphore to avoid spin-lock polling
     private let transcriptionSemaphore = TranscriptionSemaphore()
+
+    /// Cache for tokenized prompts to avoid re-tokenizing identical strings
+    private var promptTokenCache: (text: String, tokens: [Int])?
     
     // MARK: - Initialization
 
@@ -51,9 +55,17 @@ class WhisperService: @unchecked Sendable {
             throw WhisperError.downloadFailed("Could not access caches directory")
         }
 
+        let computeOptions = ModelComputeOptions(
+            melCompute: .cpuAndGPU,
+            audioEncoderCompute: .cpuAndNeuralEngine,
+            textDecoderCompute: .cpuAndNeuralEngine,
+            prefillCompute: .cpuAndNeuralEngine
+        )
+
         let config = WhisperKitConfig(
             model: modelName,
             downloadBase: cacheDir,
+            computeOptions: computeOptions,
             verbose: false,
             logLevel: .info
         )
@@ -119,9 +131,15 @@ class WhisperService: @unchecked Sendable {
             noSpeechThreshold: 0.4
         )
 
-        // Token-based prompt (converted from string)
+        // Token-based prompt (converted from string, cached to avoid re-tokenizing)
         if let prompt = initialPrompt, let tokenizer = self.tokenizer {
-            options.promptTokens = tokenizePrompt(prompt, tokenizer: tokenizer)
+            if let cached = promptTokenCache, cached.text == prompt {
+                options.promptTokens = cached.tokens
+            } else {
+                let tokens = tokenizePrompt(prompt, tokenizer: tokenizer)
+                promptTokenCache = (text: prompt, tokens: tokens)
+                options.promptTokens = tokens
+            }
             Logger.shared.info("📋 Initial prompt set (\(prompt.count) chars, \(options.promptTokens?.count ?? 0) tokens): \"\(prompt.prefix(100))...\"", category: .transcription)
         }
 
@@ -129,6 +147,12 @@ class WhisperService: @unchecked Sendable {
         let transcribeStart = Date()
         let results = try await whisperKit.transcribe(audioArray: samples, decodeOptions: options)
         let transcribeElapsed = Date().timeIntervalSince(transcribeStart)
+
+        // Log granular timing breakdown from WhisperKit
+        if let timings = results.first?.timings {
+            let ttft = timings.firstTokenTime - timings.pipelineStart
+            Logger.shared.info("📊 WhisperKit timings: encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, prefill=\(String(format: "%.3f", timings.prefill))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond)), RTF=\(String(format: "%.3f", timings.realTimeFactor))", category: .transcription)
+        }
 
         let text = results.map { $0.text }.joined(separator: " ")
             .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
@@ -139,6 +163,13 @@ class WhisperService: @unchecked Sendable {
             var fallbackOptions = options
             fallbackOptions.promptTokens = nil
             let fallbackResults = try await whisperKit.transcribe(audioArray: samples, decodeOptions: fallbackOptions)
+
+            // Log fallback timings
+            if let timings = fallbackResults.first?.timings {
+                let ttft = timings.firstTokenTime - timings.pipelineStart
+                Logger.shared.info("📊 WhisperKit timings (fallback): encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, prefill=\(String(format: "%.3f", timings.prefill))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond))", category: .transcription)
+            }
+
             let fallbackText = fallbackResults.map { $0.text }.joined(separator: " ")
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -55,12 +55,8 @@ fi
 if [ -d "$BACKUP_DIR" ]; then
     for f in vocabulary.json toggleHotkey.json; do
         if [ -f "$BACKUP_DIR/$f" ]; then
-            # Only restore if the backup has actual data (not just "[]")
-            CONTENT=$(cat "$BACKUP_DIR/$f" 2>/dev/null || true)
-            if [ -n "$CONTENT" ] && [ "$CONTENT" != "[]" ]; then
-                mkdir -p "$APP_SUPPORT_DIR"
-                cp "$BACKUP_DIR/$f" "$APP_SUPPORT_DIR/$f"
-            fi
+            mkdir -p "$APP_SUPPORT_DIR"
+            cp "$BACKUP_DIR/$f" "$APP_SUPPORT_DIR/$f"
         fi
     done
     rm -rf "$BACKUP_DIR"


### PR DESCRIPTION
## Summary

- Replace scalar audio processing loops with vectorized vDSP operations: resampling via `vDSP_vlint`, mono conversion via `vDSP_vadd`/`vDSP_vsmul`, and skip normalization when peak amplitude is already in the 0.7–1.0 range
- Configure WhisperKit with explicit `ModelComputeOptions`, routing prefill through Neural Engine instead of the CPU-only default
- Add granular timing logs from WhisperKit's `TranscriptionTimings` (encoding, decoding, prefill, TTFT, tokens/sec) and cache prompt tokenization to avoid redundant work
- Fix deploy script to unconditionally restore vocabulary backup, preventing data loss when the backed-up file contained `[]`

Closes #336

## Test plan

- [x] `swift build -c release` compiles cleanly
- [x] `swift test` — all 141 tests pass
- [ ] Deploy and dictate ~5s and ~15s clips; verify granular WhisperKit timing breakdown appears in logs
- [ ] Verify vocabulary persists across deploy cycles