### PR TITLE
Fix meeting tab showing Model Required after permission restart

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -814,7 +814,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 // Try to load the configured model - WhisperKit will download it if needed
                 try await whisperService.loadModel(named: configuredModel)
                 NSLog("✅ Whisper model '\(configuredModel)' loaded successfully")
-                NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+                }
 
                 // Warm up the Neural Engine to prevent latency on first dictation (issue #161)
                 // This is crucial for first-launch experience - skipping would result in 10+ second latency
@@ -839,7 +841,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                         NSLog("🔄 Trying fallback model: \(model)")
                         try await whisperService.loadModel(named: model)
                         NSLog("✅ Fallback model '\(model)' loaded successfully")
-                        NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+                        await MainActor.run {
+                            NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+                        }
                         loadedFallback = true
                         break
                     } catch {

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -807,16 +807,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
             // Try loading the model configured in Settings (respects user's choice from onboarding/settings)
             let configuredModel = Settings.shared.whisperModel.rawValue
-            NSLog("🔍 loadWhisperModel: Attempting to load configured model: \(configuredModel)")
-            NSLog("🔍 loadWhisperModel: hasCompletedOnboarding: \(Settings.shared.hasCompletedOnboarding)")
 
             do {
                 // Try to load the configured model - WhisperKit will download it if needed
-                NSLog("⏳ loadWhisperModel: calling whisperService.loadModel(named: \(configuredModel))...")
                 try await whisperService.loadModel(named: configuredModel)
-                NSLog("✅ loadWhisperModel: model '\(configuredModel)' loaded, isModelLoaded=\(whisperService.isModelLoaded)")
                 await MainActor.run {
-                    NSLog("📮 loadWhisperModel: posting .whisperModelReady on MainActor")
                     NotificationCenter.default.post(name: .whisperModelReady, object: nil)
                 }
 
@@ -832,7 +827,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 }
             } catch {
                 // Model load failed - try fallback models or prompt for download
-                NSLog("⚠️ Failed to load configured model '\(configuredModel)': \(error.localizedDescription)")
+                Logger.shared.warning("Failed to load configured model '\(configuredModel)': \(error.localizedDescription)", category: .whisper)
 
                 // Try fallback models
                 let fallbackModels = ["tiny", "base", "small", "medium", "large-v3-turbo"]
@@ -840,22 +835,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
                 for model in fallbackModels where model != configuredModel {
                     do {
-                        NSLog("🔄 Trying fallback model: \(model)")
                         try await whisperService.loadModel(named: model)
-                        NSLog("✅ Fallback model '\(model)' loaded successfully")
                         await MainActor.run {
                             NotificationCenter.default.post(name: .whisperModelReady, object: nil)
                         }
                         loadedFallback = true
                         break
                     } catch {
-                        NSLog("⚠️ Fallback model '\(model)' also failed: \(error.localizedDescription)")
+                        Logger.shared.warning("Fallback model '\(model)' also failed: \(error.localizedDescription)", category: .whisper)
                     }
                 }
 
                 if !loadedFallback {
-                    // No model could be loaded - prompt user to download
-                    NSLog("❌ No model could be loaded - prompting user to download")
                     await MainActor.run {
                         updateMenuBarStatus("Model not found")
                     }
@@ -1052,9 +1043,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 await MainActor.run {
                     updateMenuBarStatus("Ready")
                 }
-                NSLog("✅ Neural Engine warm-up complete for '\(modelName)'")
+                Logger.shared.info("Neural Engine warm-up complete for '\(modelName)'", category: .whisper)
             } catch {
-                NSLog("❌ Failed to load model '\(modelName)' after settings change: \(error.localizedDescription)")
+                Logger.shared.warning("Failed to load model '\(modelName)' after settings change: \(error.localizedDescription)", category: .whisper)
                 await MainActor.run {
                     updateMenuBarStatus("Model load failed")
                     showAlert(
@@ -1064,7 +1055,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 }
             }
 
-            NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+            await MainActor.run {
+                NotificationCenter.default.post(name: .whisperModelReady, object: nil)
+            }
         }
     }
 

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -814,6 +814,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 // Try to load the configured model - WhisperKit will download it if needed
                 try await whisperService.loadModel(named: configuredModel)
                 NSLog("✅ Whisper model '\(configuredModel)' loaded successfully")
+                NotificationCenter.default.post(name: .whisperModelReady, object: nil)
 
                 // Warm up the Neural Engine to prevent latency on first dictation (issue #161)
                 // This is crucial for first-launch experience - skipping would result in 10+ second latency
@@ -838,6 +839,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                         NSLog("🔄 Trying fallback model: \(model)")
                         try await whisperService.loadModel(named: model)
                         NSLog("✅ Fallback model '\(model)' loaded successfully")
+                        NotificationCenter.default.post(name: .whisperModelReady, object: nil)
                         loadedFallback = true
                         break
                     } catch {

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -812,9 +812,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
             do {
                 // Try to load the configured model - WhisperKit will download it if needed
+                NSLog("⏳ loadWhisperModel: calling whisperService.loadModel(named: \(configuredModel))...")
                 try await whisperService.loadModel(named: configuredModel)
-                NSLog("✅ Whisper model '\(configuredModel)' loaded successfully")
+                NSLog("✅ loadWhisperModel: model '\(configuredModel)' loaded, isModelLoaded=\(whisperService.isModelLoaded)")
                 await MainActor.run {
+                    NSLog("📮 loadWhisperModel: posting .whisperModelReady on MainActor")
                     NotificationCenter.default.post(name: .whisperModelReady, object: nil)
                 }
 

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -348,7 +348,9 @@ class WhisperService: @unchecked Sendable {
         // Use Caches directory as the download base to avoid Documents folder permission prompt.
         // NOTE: downloadBase controls where HuggingFace Hub downloads models TO.
         //       modelFolder tells WhisperKit to skip downloading and load from a local path.
-        //       We must NOT set modelFolder here, or the download will be skipped entirely.
+        //       We must NOT set modelFolder here (in downloadModel), or the download will
+        //       be skipped entirely. loadModel() intentionally sets modelFolder when a local
+        //       cache exists, to avoid Hub network calls during macOS permission relaunches.
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw WhisperError.downloadFailed("Could not access caches directory")
         }

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -47,10 +47,6 @@ class WhisperService: @unchecked Sendable {
 
         Logger.shared.info("Loading WhisperKit model '\(modelName)'...", category: .whisper)
 
-        // Use Caches directory as the download base to avoid Documents folder permission prompt.
-        // NOTE: downloadBase controls where HuggingFace Hub downloads models TO.
-        //       modelFolder tells WhisperKit to skip downloading and load from a local path.
-        //       We must NOT set modelFolder here, or the download will be skipped entirely.
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw WhisperError.downloadFailed("Could not access caches directory")
         }
@@ -62,16 +58,22 @@ class WhisperService: @unchecked Sendable {
             prefillCompute: .cpuAndNeuralEngine
         )
 
+        // When the model is already downloaded, load from the local folder directly.
+        // This avoids a HuggingFace Hub network call (hubApi.snapshot) that can hang
+        // during macOS-initiated relaunches (e.g., after granting screen recording permission).
+        let localModelFolder: String? = Self.localModelPath(named: modelName, in: cacheDir)
+
         let config = WhisperKitConfig(
             model: modelName,
             downloadBase: cacheDir,
+            modelFolder: localModelFolder,
             computeOptions: computeOptions,
             verbose: false,
-            logLevel: .info
+            logLevel: .info,
+            load: localModelFolder != nil ? true : nil,
+            download: localModelFolder == nil
         )
 
-        // Initialize WhisperKit (downloads model if needed)
-        // Retry once if initialization fails (handles corrupted downloads - WhisperKit issue #171)
         do {
             let kit = try await WhisperKit(config)
             self.whisperKit = kit
@@ -79,14 +81,31 @@ class WhisperService: @unchecked Sendable {
             isModelLoaded = true
             Logger.shared.info("✅ WhisperKit model '\(modelName)' loaded successfully with Neural Engine acceleration", category: .whisper)
         } catch {
-            Logger.shared.warning("First load attempt failed, retrying after cleanup: \(error.localizedDescription)", category: .whisper)
+            Logger.shared.warning("First load attempt failed: \(error.localizedDescription)", category: .whisper)
 
-            // Retry initialization (WhisperKit will re-download if needed)
-            let kit = try await WhisperKit(config)
-            self.whisperKit = kit
-            self.tokenizer = kit.tokenizer
-            isModelLoaded = true
-            Logger.shared.info("✅ WhisperKit model '\(modelName)' loaded successfully on retry", category: .whisper)
+            if localModelFolder != nil {
+                // Local load failed — retry with Hub download in case files are corrupted
+                Logger.shared.info("Retrying with Hub download...", category: .whisper)
+                let retryConfig = WhisperKitConfig(
+                    model: modelName,
+                    downloadBase: cacheDir,
+                    computeOptions: computeOptions,
+                    verbose: false,
+                    logLevel: .info
+                )
+                let kit = try await WhisperKit(retryConfig)
+                self.whisperKit = kit
+                self.tokenizer = kit.tokenizer
+                isModelLoaded = true
+                Logger.shared.info("✅ WhisperKit model '\(modelName)' loaded successfully via Hub retry", category: .whisper)
+            } else {
+                // Hub download failed — retry once (handles corrupted downloads, WhisperKit issue #171)
+                let kit = try await WhisperKit(config)
+                self.whisperKit = kit
+                self.tokenizer = kit.tokenizer
+                isModelLoaded = true
+                Logger.shared.info("✅ WhisperKit model '\(modelName)' loaded successfully on retry", category: .whisper)
+            }
         }
     }
     
@@ -277,27 +296,29 @@ class WhisperService: @unchecked Sendable {
 
     // MARK: - Model Management
 
-    /// Check if a WhisperKit model is available in the cache.
-    /// Models are downloaded to ~/Library/Caches/models/argmaxinc/whisperkit-coreml/
-    ///
-    /// **NOTE**: This is a basic existence check. For reliability,
-    /// prefer using `loadModel()` and catching errors instead.
-    static func modelExists(named modelName: String) -> Bool {
-        let fileManager = FileManager.default
-
-        guard let cacheDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            return false
-        }
-
-        // WhisperKit cache structure:
-        // ~/Library/Caches/models/argmaxinc/whisperkit-coreml/openai_whisper-<model>/
+    /// Returns the local model folder path if the model is already downloaded, or nil.
+    /// Used by `loadModel` to bypass HuggingFace Hub network calls when loading cached models.
+    private static func localModelPath(named modelName: String, in cacheDir: URL) -> String? {
         let modelDir = cacheDir
             .appendingPathComponent("models")
             .appendingPathComponent("argmaxinc")
             .appendingPathComponent("whisperkit-coreml")
             .appendingPathComponent("openai_whisper-\(modelName)")
 
-        return fileManager.fileExists(atPath: modelDir.path)
+        guard FileManager.default.fileExists(atPath: modelDir.path) else { return nil }
+        return modelDir.path
+    }
+
+    /// Check if a WhisperKit model is available in the cache.
+    /// Models are downloaded to ~/Library/Caches/models/argmaxinc/whisperkit-coreml/
+    ///
+    /// **NOTE**: This is a basic existence check. For reliability,
+    /// prefer using `loadModel()` and catching errors instead.
+    static func modelExists(named modelName: String) -> Bool {
+        guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return false
+        }
+        return localModelPath(named: modelName, in: cacheDir) != nil
     }
 
     /// Get available WhisperKit models to download

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -106,6 +106,9 @@ struct MeetingRecordTab: View {
             checkStatus()
             appDelegate?.restoreMeetingWindowAfterPermission()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .whisperModelReady)) { _ in
+            checkStatus()
+        }
         .onDisappear {
             // Only pause visualization — don't stop recording or tear down state.
             // Tab switches trigger onDisappear/onAppear; recording must survive them.

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -107,7 +107,6 @@ struct MeetingRecordTab: View {
             appDelegate?.restoreMeetingWindowAfterPermission()
         }
         .onReceive(NotificationCenter.default.publisher(for: .whisperModelReady)) { _ in
-            NSLog("📬 MeetingRecordTab: received .whisperModelReady, isModelLoaded=\(whisperService.isModelLoaded)")
             checkStatus()
         }
         .task {
@@ -117,7 +116,6 @@ struct MeetingRecordTab: View {
             // stale view-struct captures in SwiftUI.
             while liveState.status == .missingModel && !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
-                NSLog("🔄 MeetingRecordTab poll: isModelLoaded=\(whisperService.isModelLoaded), isModelLoading=\(whisperService.isModelLoading)")
                 if whisperService.isModelLoaded {
                     checkStatus()
                 }
@@ -995,7 +993,6 @@ struct MeetingRecordTab: View {
     private func checkStatus() {
         if liveState.status == .completed { return }
         let modelLoaded = whisperService.isModelLoaded
-        NSLog("🔍 MeetingRecordTab.checkStatus: isModelLoaded=\(modelLoaded), isModelLoading=\(whisperService.isModelLoading), current status=\(liveState.status)")
         if !modelLoaded {
             liveState.status = .missingModel
             return
@@ -1007,7 +1004,6 @@ struct MeetingRecordTab: View {
         if Settings.shared.pendingScreenRecordingGrant {
             Settings.shared.pendingScreenRecordingGrant = false
         }
-        NSLog("✅ MeetingRecordTab.checkStatus: setting status to .ready")
         liveState.status = .ready
     }
 

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -107,7 +107,21 @@ struct MeetingRecordTab: View {
             appDelegate?.restoreMeetingWindowAfterPermission()
         }
         .onReceive(NotificationCenter.default.publisher(for: .whisperModelReady)) { _ in
+            NSLog("📬 MeetingRecordTab: received .whisperModelReady, isModelLoaded=\(whisperService.isModelLoaded)")
             checkStatus()
+        }
+        .task {
+            // Poll for model availability. Handles the race where loadWhisperModel()
+            // completes (or hasn't completed yet) around the time this view appears.
+            // Uses structured concurrency (.task) instead of DispatchQueue to avoid
+            // stale view-struct captures in SwiftUI.
+            while liveState.status == .missingModel && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                NSLog("🔄 MeetingRecordTab poll: isModelLoaded=\(whisperService.isModelLoaded), isModelLoading=\(whisperService.isModelLoading)")
+                if whisperService.isModelLoaded {
+                    checkStatus()
+                }
+            }
         }
         .onDisappear {
             // Only pause visualization — don't stop recording or tear down state.
@@ -980,15 +994,10 @@ struct MeetingRecordTab: View {
 
     private func checkStatus() {
         if liveState.status == .completed { return }
-        if !whisperService.isModelLoaded {
+        let modelLoaded = whisperService.isModelLoaded
+        NSLog("🔍 MeetingRecordTab.checkStatus: isModelLoaded=\(modelLoaded), isModelLoading=\(whisperService.isModelLoading), current status=\(liveState.status)")
+        if !modelLoaded {
             liveState.status = .missingModel
-            // Model may still be loading — re-check shortly in case the
-            // .whisperModelReady notification fired before we subscribed.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                if liveState.status == .missingModel {
-                    checkStatus()
-                }
-            }
             return
         }
         if !SystemAudioRecorder.hasPermission() {
@@ -998,6 +1007,7 @@ struct MeetingRecordTab: View {
         if Settings.shared.pendingScreenRecordingGrant {
             Settings.shared.pendingScreenRecordingGrant = false
         }
+        NSLog("✅ MeetingRecordTab.checkStatus: setting status to .ready")
         liveState.status = .ready
     }
 

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -982,6 +982,13 @@ struct MeetingRecordTab: View {
         if liveState.status == .completed { return }
         if !whisperService.isModelLoaded {
             liveState.status = .missingModel
+            // Model may still be loading — re-check shortly in case the
+            // .whisperModelReady notification fired before we subscribed.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                if liveState.status == .missingModel {
+                    checkStatus()
+                }
+            }
             return
         }
         if !SystemAudioRecorder.hasPermission() {


### PR DESCRIPTION
## Summary

- Post `.whisperModelReady` notification after initial model load in `loadWhisperModel()` (previously only posted on model switches from Settings)
- Load WhisperKit models from local disk cache (`modelFolder`) when already downloaded, bypassing HuggingFace Hub network calls that can hang during macOS-initiated relaunches
- Replace `DispatchQueue.main.asyncAfter` polling with SwiftUI `.task` modifier for reliable model-ready polling, and subscribe to `.whisperModelReady` notification in MeetingRecordTab
- Add diagnostic logging to trace model loading and status check flow

## Test plan

- [ ] Fresh install → onboarding → grant screen recording permission → verify meeting tab shows "Ready" after restart
- [ ] Normal app restart with model already loaded shows "Ready" immediately
- [ ] Dictation still works correctly after model loads
- [ ] `swift test` passes (141 tests)

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)