### PR TITLE
Replace Caps Lock with double-tap Right Option as default hotkey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 **Look Ma No Hands** - macOS menu bar app for system-wide voice dictation and meeting transcription.
 
 **Core Features**:
-- Press Caps Lock → Record → Speak → Auto-insert formatted text anywhere
+- Double-tap Right Option → Record → Speak → Auto-insert formatted text anywhere
 - Meeting mode (active): System audio capture + structured notes via Ollama
 - 100% local processing (whisper.cpp + optional Ollama)
 
@@ -265,7 +265,7 @@ Unsure if tool is available?
 | Platform | macOS 14+ (Sonoma) for @Observable macro |
 | No Xcode | SPM command-line only |
 | Local only | No cloud services, no data leaves device |
-| Caps Lock trigger | Preferred key (with fallback to Right Option/Fn if needed) |
+| Right Option trigger | Double-tap Right Option (default, with Fn and custom alternatives) |
 
 ## Current Dependencies
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Fast, local voice dictation and meeting transcription for macOS. Use custom keyb
 - **Lightning Fast**: ~1 second transcription with WhisperKit acceleration on Apple Neural Engine
 - **System-wide**: Works in any app, any text field
 - **Fully Customizable Hotkeys**:
-  - Caps Lock toggle (default, press once to start, again to stop)
+  - Double-tap Right Option (default) to start/stop recording
   - Custom key combinations with real-time validation
-  - Predefined alternatives (Right Option, Fn key)
+  - Predefined alternative: Fn key (double-tap)
   - Dynamic switching without app restart
   - System-reserved hotkey protection
 - **Hotkey Toggle**: Global keyboard shortcut (Cmd+Shift+D) to temporarily disable/enable dictation. State persists across restarts.
@@ -138,7 +138,7 @@ ollama pull qwen2.5:3b
 
 On first launch, grant:
 1. **Microphone access**: To capture your voice for dictation
-2. **Accessibility access**: To insert text and monitor Caps Lock key
+2. **Accessibility access**: To insert text and monitor the dictation hotkey
 3. **Screen recording** (optional): Required for system audio capture in meeting transcription
 
 <p align="center">
@@ -195,7 +195,7 @@ Access via menu bar → **Settings** to:
   - Configure recording hotkey with real-time validation (Raycast-style hotkey recorder)
   - Hotkey toggle enabled/disabled state
   - Recording indicator style preferences
-  - Predefined hotkey shortcuts (Caps Lock, Right Option, Fn)
+  - Predefined hotkey shortcuts (Right Option, Fn)
 - **Models Tab**:
   - Download and switch Whisper models (tiny, base, small, medium, large-v3-turbo)
   - Configure Ollama model for meeting notes
@@ -297,9 +297,9 @@ In the Meeting Transcription window:
 - Some apps restrict accessibility—Look Ma No Hands falls back to clipboard
 - Check Accessibility permissions in System Settings
 
-**Caps Lock not working?**
-- The app monitors Caps Lock presses (doesn't change actual Caps Lock state)
+**Hotkey not working?**
 - Ensure Accessibility permission is granted
+- Try double-tapping Right Option quickly (within 400ms)
 
 ### Meeting Transcription Issues
 
@@ -425,7 +425,7 @@ For the full audit summary, resolved findings, and current security posture, see
 ## 🚧 Known Limitations
 
 ### Voice Dictation
-- Caps Lock monitoring requires Accessibility permission
+- Hotkey monitoring requires Accessibility permission
 - Some sandboxed apps may not allow direct text insertion
 - Best accuracy with clear audio in quiet environments
 - English-only (Whisper supports other languages, but not tested)

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1127,7 +1127,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
     // MARK: - Recording Workflow
 
-    /// Handle hotkey press (Caps Lock, etc.) - toggles recording
+    /// Handle hotkey press (Right Option double-tap, etc.) - toggles recording
     /// This method respects the hotkeyEnabled setting
     private func handleHotkeyTrigger() {
         guard Settings.shared.hotkeyEnabled else {
@@ -1370,7 +1370,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     private func showAccessibilityPermissionAlert() {
         let alert = NSAlert()
         alert.messageText = "Accessibility Permission Required"
-        alert.informativeText = "Look Ma No Hands needs accessibility permission to:\n\n• Monitor the Caps Lock key\n• Insert transcribed text into other apps\n\nClick 'Open System Settings' to grant permission, then restart the app."
+        alert.informativeText = "Look Ma No Hands needs accessibility permission to:\n\n• Monitor the dictation hotkey\n• Insert transcribed text into other apps\n\nClick 'Open System Settings' to grant permission, then restart the app."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Cancel")

--- a/Sources/LookMaNoHands/Models/Hotkey.swift
+++ b/Sources/LookMaNoHands/Models/Hotkey.swift
@@ -79,20 +79,19 @@ struct Hotkey: Codable, Equatable, Hashable, Sendable {
         return parts.joined(separator: "+")
     }
 
-    /// Check if this hotkey is a single modifier key (Caps Lock, Fn, etc.)
+    /// Check if this hotkey is a single modifier key (Right Option, Fn, etc.)
     var isSingleModifierKey: Bool {
         !modifiers.hasModifiers && Hotkey.isModifierKeyCode(keyCode)
     }
 
     /// Predefined hotkeys for common trigger keys
-    static let capsLock = Hotkey(keyCode: 57, modifiers: .init())
     static let rightOption = Hotkey(keyCode: 61, modifiers: .init())
     static let fn = Hotkey(keyCode: 63, modifiers: .init())
 
     /// Check if this is one of the predefined single-key triggers
     /// These are exempt from the 2-3 keypress validation rule
     var isPredefinedTrigger: Bool {
-        self == .capsLock || self == .rightOption || self == .fn
+        self == .rightOption || self == .fn
     }
 
     // MARK: - Key Code Utilities

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -2,8 +2,7 @@ import Foundation
 
 /// Available trigger keys for starting/stopping recording
 enum TriggerKey: String, CaseIterable, Identifiable, Sendable {
-    case capsLock = "Caps Lock"
-    case rightOption = "Right Option"
+    case rightOption = "Right Option (Double-tap)"
     case fn = "Fn (Double-tap)"
     case custom = "Custom..."
 
@@ -12,7 +11,6 @@ enum TriggerKey: String, CaseIterable, Identifiable, Sendable {
     /// Get the Hotkey for this trigger key
     func toHotkey(customHotkey: Hotkey?) -> Hotkey? {
         switch self {
-        case .capsLock: return .capsLock
         case .rightOption: return .rightOption
         case .fn: return .fn
         case .custom: return customHotkey
@@ -354,7 +352,7 @@ Now produce the complete meeting notes following the format above. Ensure every 
 
     /// Get the effective hotkey based on current settings
     var effectiveHotkey: Hotkey {
-        triggerKey.toHotkey(customHotkey: customHotkey) ?? .capsLock
+        triggerKey.toHotkey(customHotkey: customHotkey) ?? .rightOption
     }
     
     /// The Whisper model to use for transcription
@@ -538,11 +536,17 @@ Now produce the complete meeting notes following the format above. Ensure every 
     private init() {
         // Load saved values or use defaults
         
+        // Migration: Caps Lock was removed as a trigger option; also handle old "Right Option" raw value
+        if let saved = UserDefaults.standard.string(forKey: Keys.triggerKey),
+           (saved == "Caps Lock" || saved == "Right Option") {
+            UserDefaults.standard.set(TriggerKey.rightOption.rawValue, forKey: Keys.triggerKey)
+        }
+
         if let savedTriggerKey = UserDefaults.standard.string(forKey: Keys.triggerKey),
            let key = TriggerKey(rawValue: savedTriggerKey) {
             self.triggerKey = key
         } else {
-            self.triggerKey = .capsLock
+            self.triggerKey = .rightOption
         }
 
         // Load custom hotkey if saved
@@ -804,7 +808,7 @@ Now produce the complete meeting notes following the format above. Ensure every 
 
     /// Reset all settings to defaults
     func resetToDefaults() {
-        triggerKey = .capsLock
+        triggerKey = .rightOption
         customHotkey = nil
         whisperModel = .base
         ollamaModel = "qwen2.5:3b"

--- a/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
+++ b/Sources/LookMaNoHands/Services/KeyboardMonitor.swift
@@ -22,7 +22,7 @@ class KeyboardMonitor: @unchecked Sendable {
     private var onCancel: CancellationCallback?
 
     /// The hotkey configuration to listen for
-    private var hotkey: Hotkey = .capsLock
+    private var hotkey: Hotkey = .rightOption
 
     /// Lock for thread-safe hotkey access
     private let hotkeyLock = NSLock()
@@ -35,6 +35,12 @@ class KeyboardMonitor: @unchecked Sendable {
 
     /// Track modifier key state to avoid double-triggering
     private var lastModifierFlags: CGEventFlags = []
+
+    /// Track Right Option press time for double-tap detection
+    private var lastRightOptionPressTime: Date?
+
+    /// Time window for double-tap detection (400ms, matching macOS conventions)
+    private let doubleTapInterval: TimeInterval = 0.4
 
     // MARK: - Public Methods
 
@@ -61,12 +67,12 @@ class KeyboardMonitor: @unchecked Sendable {
 
     /// Start monitoring for the trigger key
     /// - Parameters:
-    ///   - hotkey: The hotkey to monitor for (defaults to Caps Lock)
+    ///   - hotkey: The hotkey to monitor for (defaults to Right Option)
     ///   - callback: Called when the trigger key is pressed
     ///   - showPrompt: Whether to show the system permission prompt if not granted (defaults to false)
     /// - Returns: True if monitoring started successfully
     @discardableResult
-    func startMonitoring(hotkey: Hotkey = .capsLock, showPrompt: Bool = false, onTrigger callback: @escaping TriggerCallback) -> Bool {
+    func startMonitoring(hotkey: Hotkey = .rightOption, showPrompt: Bool = false, onTrigger callback: @escaping TriggerCallback) -> Bool {
         guard !isMonitoring else { return true }
 
         // Check accessibility permission (optionally prompting)
@@ -87,7 +93,7 @@ class KeyboardMonitor: @unchecked Sendable {
         self.onTrigger = callback
 
         // Determine which events to monitor
-        // For single modifier keys (Caps Lock, etc.), monitor flagsChanged
+        // For single modifier keys (Right Option, Fn, etc.), monitor flagsChanged
         // For key+modifier combinations, monitor keyDown
         // Monitor both to support dynamic switching
         var eventMask: CGEventMask = 0
@@ -112,7 +118,6 @@ class KeyboardMonitor: @unchecked Sendable {
             let shouldConsume = monitor.handleEvent(type: type, event: event)
 
             // If handleEvent returned true, consume the event (return nil) to prevent system handling
-            // This fixes the issue where Caps Lock would trigger Music app and other system shortcuts
             if shouldConsume {
                 return nil // Consume event - prevent propagation
             }
@@ -220,7 +225,7 @@ class KeyboardMonitor: @unchecked Sendable {
         let currentHotkey = getHotkey()
 
         if currentHotkey.isSingleModifierKey {
-            // Handle single modifier keys (Caps Lock, Right Option, Fn, etc.)
+            // Handle single modifier keys (Right Option, Fn, etc.)
             guard type == .flagsChanged else { return false }
 
             let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
@@ -232,8 +237,6 @@ class KeyboardMonitor: @unchecked Sendable {
             // Determine the relevant flag for this modifier key
             let relevantFlag: CGEventFlags
             switch currentHotkey.keyCode {
-            case 57: // Caps Lock
-                relevantFlag = .maskAlphaShift
             case 61: // Right Option
                 relevantFlag = .maskAlternate
             case 63: // Fn
@@ -249,34 +252,34 @@ class KeyboardMonitor: @unchecked Sendable {
             // Update state
             lastModifierFlags = eventFlags
 
-            // For Caps Lock (a toggle key), trigger on BOTH press and release
-            // For other modifier keys, only trigger on press
-            let shouldTrigger: Bool
-            if currentHotkey.keyCode == 57 { // Caps Lock
-                // Trigger on any state change (toggle)
-                shouldTrigger = isPressed != wasPressed
-            } else {
-                // Trigger only on press (not release)
-                shouldTrigger = isPressed && !wasPressed
-            }
+            // Only trigger on press (not release)
+            guard isPressed && !wasPressed else { return false }
 
-            if shouldTrigger {
-                NSLog("🔔 KeyboardMonitor: %@ detected (toggle/press) - consuming event", currentHotkey.displayString)
-                DispatchQueue.main.async { [weak self] in
-                    self?.onTrigger?()
+            // For Right Option, require double-tap to avoid interfering with normal Option usage
+            if currentHotkey.keyCode == 61 {
+                let now = Date()
+                if let lastPress = lastRightOptionPressTime,
+                   now.timeIntervalSince(lastPress) <= doubleTapInterval {
+                    // Double-tap detected — trigger and reset
+                    lastRightOptionPressTime = nil
+                    NSLog("🔔 KeyboardMonitor: %@ double-tap detected - consuming event", currentHotkey.displayString)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onTrigger?()
+                    }
+                    return true // Consume second tap
+                } else {
+                    // First tap — record time, don't consume
+                    lastRightOptionPressTime = now
+                    return false
                 }
-                return true // Consume the event to prevent system handling (e.g., Music app)
             }
 
-            // For Caps Lock, always consume the key event to prevent system interference
-            // even during state transitions (e.g., toggle off after recording)
-            // This prevents Music app launch and other system shortcuts from triggering
-            if currentHotkey.keyCode == 57 { // Caps Lock
-                return true
+            // For other single modifier keys (Fn), trigger on press
+            NSLog("🔔 KeyboardMonitor: %@ detected (press) - consuming event", currentHotkey.displayString)
+            DispatchQueue.main.async { [weak self] in
+                self?.onTrigger?()
             }
-
-            // For other modifier keys, only consume when we trigger
-            return false
+            return true
         } else {
             // Handle key+modifier combinations
             // Only process keyDown events for key+modifier combinations

--- a/Sources/LookMaNoHands/Views/HotkeyRecorderView.swift
+++ b/Sources/LookMaNoHands/Views/HotkeyRecorderView.swift
@@ -173,7 +173,7 @@ struct HotkeyRecorderView: View {
             return "Reserved by system"
         }
 
-        // Predefined triggers (Caps Lock, Fn, Right Option) are always valid
+        // Predefined triggers (Right Option, Fn) are always valid
         // These are special system keys that work with single keypress
         if hotkey.isPredefinedTrigger {
             return nil

--- a/Sources/LookMaNoHands/Views/OnboardingView.swift
+++ b/Sources/LookMaNoHands/Views/OnboardingView.swift
@@ -579,7 +579,7 @@ struct PermissionsStepView: View {
                 PermissionCard(
                     icon: "accessibility",
                     title: "Accessibility",
-                    description: "Monitor Caps Lock and insert text into apps",
+                    description: "Monitor hotkey and insert text into apps",
                     isGranted: onboardingState.hasAccessibilityPermission,
                     actionTitle: "Open System Settings",
                     action: {

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -764,7 +764,7 @@ struct SettingsView: View {
                         Text("Dictation")
                             .font(.headline)
                             .fontWeight(.semibold)
-                        Text("Voice-to-text using Whisper (Caps Lock trigger)")
+                        Text("Voice-to-text using Whisper (double-tap Right Option)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -1332,7 +1332,7 @@ struct SettingsView: View {
                 FeatureListItem(icon: "bolt.fill", text: "Lightning-fast transcription with Whisper")
                 FeatureListItem(icon: "lock.fill", text: "100% local - your voice never leaves your Mac")
                 FeatureListItem(icon: "waveform", text: "Smart text formatting and punctuation")
-                FeatureListItem(icon: "keyboard", text: "Works in any app with Caps Lock trigger")
+                FeatureListItem(icon: "keyboard", text: "Works in any app with double-tap Right Option")
             }
             .frame(maxWidth: 400)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -144,7 +144,7 @@ Expected Result:
    #endif
 
 2. Perform a transcription to populate lastTranscription:
-   - Press trigger key (Caps Lock)
+   - Press trigger key (double-tap Right Option)
    - Say something (e.g., "This is a test transcription")
    - Verify text was transcribed
 

--- a/Tests/LookMaNoHandsTests/HotkeyTests.swift
+++ b/Tests/LookMaNoHandsTests/HotkeyTests.swift
@@ -19,7 +19,6 @@ final class HotkeyTests: XCTestCase {
     }
 
     func testSingleModifierKeysAndReserved() {
-        XCTAssertTrue(Hotkey.capsLock.isSingleModifierKey)
         XCTAssertTrue(Hotkey.fn.isSingleModifierKey)
         XCTAssertTrue(Hotkey.rightOption.isSingleModifierKey)
 
@@ -31,7 +30,6 @@ final class HotkeyTests: XCTestCase {
     }
 
     func testIsPredefinedTrigger() {
-        XCTAssertTrue(Hotkey.capsLock.isPredefinedTrigger)
         XCTAssertTrue(Hotkey.rightOption.isPredefinedTrigger)
         XCTAssertTrue(Hotkey.fn.isPredefinedTrigger)
 

--- a/Tests/LookMaNoHandsTests/SettingsTests.swift
+++ b/Tests/LookMaNoHandsTests/SettingsTests.swift
@@ -35,7 +35,6 @@ final class SettingsTests: XCTestCase {
 
     func testTriggerKeyToHotkey() {
         let custom = Hotkey(keyCode: 2, modifiers: .init(command: true))
-        XCTAssertEqual(TriggerKey.capsLock.toHotkey(customHotkey: nil), .capsLock)
         XCTAssertEqual(TriggerKey.rightOption.toHotkey(customHotkey: nil), .rightOption)
         XCTAssertEqual(TriggerKey.fn.toHotkey(customHotkey: nil), .fn)
         XCTAssertEqual(TriggerKey.custom.toHotkey(customHotkey: custom), custom)
@@ -56,7 +55,7 @@ final class SettingsTests: XCTestCase {
 
         settings.resetToDefaults()
 
-        XCTAssertEqual(settings.triggerKey, .capsLock)
+        XCTAssertEqual(settings.triggerKey, .rightOption)
         XCTAssertEqual(settings.whisperModel, .base)
         XCTAssertTrue(settings.showIndicator)
         XCTAssertTrue(settings.pauseMediaDuringDictation)

--- a/Tests/LookMaNoHandsTests/ViewStateTests.swift
+++ b/Tests/LookMaNoHandsTests/ViewStateTests.swift
@@ -6,7 +6,7 @@ final class ViewStateTests: XCTestCase {
         let status = LaunchSplashView.statusAccessibility(hotkeyEnabled: false)
         let hint = LaunchSplashView.hintAccessibility(
             hotkeyEnabled: false,
-            hotkeyDisplay: "Caps Lock"
+            hotkeyDisplay: "⌥R"
         )
 
         XCTAssertEqual(status, "Hotkey paused")
@@ -17,11 +17,11 @@ final class ViewStateTests: XCTestCase {
         let status = LaunchSplashView.statusAccessibility(hotkeyEnabled: true)
         let hint = LaunchSplashView.hintAccessibility(
             hotkeyEnabled: true,
-            hotkeyDisplay: "Caps Lock"
+            hotkeyDisplay: "⌥R"
         )
 
         XCTAssertEqual(status, "App ready")
-        XCTAssertEqual(hint, "Press Caps Lock to start recording")
+        XCTAssertEqual(hint, "Press ⌥R to start recording")
     }
 
     func testOllamaPickerIncludesCurrentModelWhenMissing() {

--- a/Tests/LookMaNoHandsTests/WhisperDictationTests.swift
+++ b/Tests/LookMaNoHandsTests/WhisperDictationTests.swift
@@ -33,7 +33,7 @@ final class WhisperDictationTests: XCTestCase {
         // After reset, should have default values
         settings.resetToDefaults()
         
-        XCTAssertEqual(settings.triggerKey, .capsLock)
+        XCTAssertEqual(settings.triggerKey, .rightOption)
         XCTAssertEqual(settings.whisperModel, .base)
         XCTAssertTrue(settings.showIndicator)
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@
 │  ┌──────▼──────┐    ┌───────▼───────┐   ┌──────▼──────┐         │
 │  │  Keyboard   │    │    Audio      │   │    Text     │         │
 │  │  Monitor    │    │   Capture     │   │  Insertion  │         │
-│  │ (Caps Lock) │    │ (Microphone)  │   │(Accessibility│         │
+│  │(Right Opt.) │    │ (Microphone)  │   │(Accessibility│         │
 │  └─────────────┘    └───────┬───────┘   └─────────────┘         │
 │                             │                                    │
 │                    ┌────────▼────────┐                           │
@@ -54,7 +54,7 @@
 
 ### 1. Keyboard Monitor (KeyboardMonitor.swift)
 
-**Purpose**: Detect Caps Lock key press system-wide
+**Purpose**: Detect dictation hotkey press system-wide (default: double-tap Right Option)
 
 **Technology**: CGEvent tap
 
@@ -64,11 +64,9 @@
 - `kCGEventFlagsChanged` - Detect modifier key changes
 
 **Challenges**:
-- Caps Lock is a modifier key, handled differently by macOS
-- May need to intercept and suppress the normal Caps Lock behavior
+- Right Option is a modifier key, handled differently by macOS
+- Double-tap detection requires tracking press timestamps within a 400ms window
 - Requires Accessibility permissions
-
-**Fallback**: If Caps Lock proves problematic, support Right Option key or custom shortcut
 
 ### 2. Audio Recorder (AudioRecorder.swift)
 
@@ -180,7 +178,7 @@
 ## Data Flow
 
 ```
-1. User presses Caps Lock
+1. User double-taps Right Option
          │
          ▼
 2. KeyboardMonitor detects press
@@ -191,7 +189,7 @@
    - AudioRecorder begins capturing
          │
          ▼
-4. User presses Caps Lock again
+4. User double-taps Right Option again
          │
          ▼
 5. Recording stops

--- a/docs/index.html
+++ b/docs/index.html
@@ -856,7 +856,7 @@
 
   <div class="track reveal reveal-d7">
     <span class="track-title">Flexible Hotkeys</span>
-    <span class="track-desc">Caps Lock is just the default. Configure any key combo, double-tap Fn, or Right Option. Toggle dictation on and off with Cmd+Shift+D.</span>
+    <span class="track-desc">Double-tap Right Option is the default. Configure any key combo or double-tap Fn. Toggle dictation on and off with Cmd+Shift+D.</span>
     <span class="track-duration">Custom</span>
   </div>
 </section>
@@ -902,7 +902,7 @@
 
     <div class="note reveal reveal-d1">
       <div class="note-num">2</div>
-      <h3>Press <kbd>Caps Lock</kbd></h3>
+      <h3>Double-tap <kbd>Right Option</kbd></h3>
       <p>Or set any custom hotkey. A floating indicator appears to confirm you're recording.</p>
     </div>
 

--- a/docs/security-future-roadmap.md
+++ b/docs/security-future-roadmap.md
@@ -519,7 +519,7 @@ This document analyzes the security threats facing Look Ma No Hands, a privacy-f
 **Current Mitigations**:
 - App only reads text fields when actively inserting transcription
 - 200-character context limit reduces exposure
-- User controls when recording happens (Caps Lock trigger)
+- User controls when recording happens (hotkey trigger)
 
 **Residual Risk**: Any app with accessibility permissions can read all text fields
 

--- a/preview/screens/launch-splash.html
+++ b/preview/screens/launch-splash.html
@@ -105,7 +105,7 @@
             <span>Ready</span>
           </div>
           <div class="splash-divider"></div>
-          <div class="splash-hint">Press Caps Lock to record</div>
+          <div class="splash-hint">Double-tap Right Option to record</div>
         </div>
         <div class="state-label">Ready (hotkeyEnabled = true)</div>
       </div>

--- a/preview/screens/onboarding.html
+++ b/preview/screens/onboarding.html
@@ -294,7 +294,7 @@
             '<div class="perm-icon" style="color:var(--color-green)">' + sfIcon('accessibility', 24) + '</div>' +
             '<div class="perm-info">' +
               '<div class="perm-title">Accessibility</div>' +
-              '<div class="perm-desc">Monitor Caps Lock and insert text into apps</div>' +
+              '<div class="perm-desc">Monitor hotkey and insert text into apps</div>' +
             '</div>' +
             '<div class="perm-status" style="color:var(--color-green)">' + sfIcon('checkmark.circle.fill', 22) + '</div>' +
           '</div>' +

--- a/preview/screens/settings.html
+++ b/preview/screens/settings.html
@@ -271,8 +271,8 @@
             <div class="form-row" style="margin-bottom:var(--space-4)">
               <div class="form-label">Trigger key</div>
               <div style="display:flex; gap:var(--space-2)">
-                <span class="keycap">⇪ Caps Lock</span>
-                <span style="color:var(--color-text-tertiary)">(recommended)</span>
+                <span class="keycap">⌥R Right Option (Double-tap)</span>
+                <span style="color:var(--color-text-tertiary)">(default)</span>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Removes Caps Lock entirely as a predefined trigger option
- Makes double-tap Right Option (400ms window) the new default dictation hotkey
- Adds migration for existing users with Caps Lock selected → auto-migrated to Right Option
- Updates all UI text, documentation, GitHub Pages website, preview HTML files, and tests (20 files, 141 tests pass)

## Key implementation details
- `KeyboardMonitor` tracks `lastRightOptionPressTime` for double-tap detection; single presses pass through to the system
- `TriggerKey.rightOption` raw value changed to `"Right Option (Double-tap)"` with migration handling for old `"Right Option"` and `"Caps Lock"` values
- Historical docs (DECISIONS.md, iOS feasibility research, archived plans) retain Caps Lock references as historical context

## Test plan
- [ ] `swift build -c release` succeeds
- [ ] `swift test` — all 141 tests pass
- [ ] `rg -i "caps.?lock" Sources/ Tests/` returns only migration code and key code comment
- [ ] Double-tap Right Option triggers dictation in deployed app
- [ ] Single Right Option press does NOT trigger dictation
- [ ] Settings UI shows "Right Option (Double-tap)" as default trigger
- [ ] Existing users with Caps Lock selected are migrated to Right Option on upgrade

Closes #342