### PR TITLE
Run security checks only on PRs, not on merge to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,6 @@
 name: Security Checks
 
 on:
-  push:
-    branches: [ main, security-* ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/**'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
     branches: [ main ]
 
@@ -25,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
-        if: github.event_name == 'pull_request'
         id: filter
         with:
           filters: |
@@ -40,7 +31,7 @@ jobs:
   verify-dependencies:
     name: Verify Package.resolved Integrity
     needs: [changes]
-    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout code
@@ -74,7 +65,7 @@ jobs:
   build-verification:
     name: Verify Clean Build
     needs: [changes]
-    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout code
@@ -92,7 +83,7 @@ jobs:
   secret-scan:
     name: Scan for Secrets
     needs: [changes]
-    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -108,7 +99,7 @@ jobs:
   dependency-scan:
     name: Scan Dependencies for Vulnerabilities
     needs: [changes]
-    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -141,7 +132,7 @@ jobs:
   entitlements-check:
     name: Verify App Entitlements
     needs: [changes]
-    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Remove `push` trigger on `main` branch from security workflow to prevent duplicate runs
- Security checks were running twice: once on the PR and again on the merge commit to main
- Clean up now-unnecessary `github.event_name == 'push'` conditions from job filters
- Remove redundant `if: github.event_name == 'pull_request'` guard on paths-filter step

## Test plan

- [ ] Verify security checks run on this PR
- [ ] After merge, confirm no security workflow triggers on the merge commit to main