### PR TITLE
Suppress transcribing indicator flash for short dictations

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.7</string>
+	<string>1.5.8</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>24</string>
+	<string>25</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1427,17 +1427,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         updateMenuBarIcon(isRecording: false)
 
         // DESIGN: Recording indicator hides immediately when recording stops.
-        // A processing indicator appears after 500ms if transcription is still running.
+        // A processing indicator appears after 750ms if transcription is still running.
         // This makes short dictations feel instant while giving feedback for longer ones.
         recordingIndicator.hide()
 
-        // Schedule processing indicator to appear after 500ms (avoids flash for fast transcriptions)
+        // Schedule processing indicator to appear after 750ms (avoids flash for fast transcriptions)
         pendingProcessingIndicator?.cancel()
         let processingWorkItem = DispatchWorkItem { [weak self] in
             self?.recordingIndicator.showProcessing()
         }
         pendingProcessingIndicator = processingWorkItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: processingWorkItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: processingWorkItem)
 
         // Resume system media if we paused it
         if Settings.shared.pauseMediaDuringDictation {

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -289,6 +289,7 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
     private var audioUpdateTimer: DispatchSourceTimer?
     private weak var audioRecorder: AudioRecorder?
     private let state = RecordingIndicatorState()
+    private var processingShownAt: Date?
 
     init() {
         // Create window once during initialization
@@ -429,14 +430,28 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
         guard let window = window else { return }
 
         state.isProcessing = true
+        processingShownAt = Date()
 
         // Cancel any in-progress hide animation before showing
         window.animator().alphaValue = 1.0
         window.orderFront(nil)
     }
 
-    /// Hide the processing indicator
+    /// Hide the processing indicator with minimum display duration to prevent flash
     func hideProcessing() {
+        let minimumDisplayDuration: TimeInterval = 0.4
+        if let shownAt = processingShownAt {
+            let elapsed = Date().timeIntervalSince(shownAt)
+            if elapsed < minimumDisplayDuration {
+                DispatchQueue.main.asyncAfter(deadline: .now() + (minimumDisplayDuration - elapsed)) { [weak self] in
+                    self?.processingShownAt = nil
+                    self?.state.isProcessing = false
+                    self?.hide()
+                }
+                return
+            }
+        }
+        processingShownAt = nil
         state.isProcessing = false
         hide()
     }


### PR DESCRIPTION
## Summary
- Increase processing indicator delay from 500ms to 750ms so most short dictations complete before the indicator ever appears
- Add 400ms minimum display duration to `hideProcessing()` to prevent a distracting flash when transcription finishes immediately after the indicator shows
- Add `processingShownAt` timestamp tracking to `RecordingIndicatorWindowController`

Closes #346

## Test plan
- [ ] Short dictation (1-2 words): "Transcribing..." indicator should not appear at all
- [ ] Medium dictation (5-10 words): if indicator appears, it stays visible for at least 400ms
- [ ] Long dictation: indicator appears after 750ms and hides normally when transcription completes
- [ ] Recording indicator (waveform) still hides immediately when recording stops
- [ ] All 141 existing tests pass