### PR TITLE
Fix processing indicator race conditions

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.8</string>
+	<string>1.5.9</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1187,6 +1187,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
 
         // Update UI
         updateMenuBarIcon(isRecording: false)
+        pendingProcessingIndicator?.cancel()
+        pendingProcessingIndicator = nil
         recordingIndicator.hide()
 
         // Resume system media if we paused it

--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -290,6 +290,7 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
     private weak var audioRecorder: AudioRecorder?
     private let state = RecordingIndicatorState()
     private var processingShownAt: Date?
+    private var pendingHideWorkItem: DispatchWorkItem?
 
     init() {
         // Create window once during initialization
@@ -429,6 +430,10 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
     func showProcessing() {
         guard let window = window else { return }
 
+        // Cancel any pending deferred hide from a previous session
+        pendingHideWorkItem?.cancel()
+        pendingHideWorkItem = nil
+
         state.isProcessing = true
         processingShownAt = Date()
 
@@ -439,15 +444,21 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
 
     /// Hide the processing indicator with minimum display duration to prevent flash
     func hideProcessing() {
+        pendingHideWorkItem?.cancel()
+        pendingHideWorkItem = nil
+
         let minimumDisplayDuration: TimeInterval = 0.4
         if let shownAt = processingShownAt {
             let elapsed = Date().timeIntervalSince(shownAt)
             if elapsed < minimumDisplayDuration {
-                DispatchQueue.main.asyncAfter(deadline: .now() + (minimumDisplayDuration - elapsed)) { [weak self] in
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.pendingHideWorkItem = nil
                     self?.processingShownAt = nil
                     self?.state.isProcessing = false
                     self?.hide()
                 }
+                pendingHideWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + (minimumDisplayDuration - elapsed), execute: workItem)
                 return
             }
         }
@@ -459,6 +470,10 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
     /// Show the recording indicator
     func show() {
         guard let window = window else { return }
+
+        // Cancel any pending deferred hide from a previous session
+        pendingHideWorkItem?.cancel()
+        pendingHideWorkItem = nil
 
         // Ensure we're in recording mode (not processing)
         state.isProcessing = false


### PR DESCRIPTION
## Summary

- Cancel `pendingProcessingIndicator` in the ESC cancel path, which was missing cleanup that both the success and error paths already perform. Without this, the processing indicator could appear ~750ms after a cancelled recording.
- Replace the fire-and-forget `DispatchQueue.main.asyncAfter` in `hideProcessing()` with a stored, cancellable `DispatchWorkItem`. This prevents a stale deferred `hide()` from dismissing the indicator during a subsequent recording session.
- Cancel pending deferred hides in both `show()` and `showProcessing()` to ensure a new session always starts clean.

Fixes identified during code review of #347.

## Test plan

- [ ] Start dictation, press ESC to cancel within 750ms — verify no processing indicator appears afterward
- [ ] Do a short dictation that triggers the processing indicator, then immediately start another dictation — verify the indicator for the new session is not dismissed by the previous session's deferred hide
- [ ] Normal dictation flow still works: recording indicator appears, processing indicator shows for longer transcriptions, and hides cleanly