### PR TITLE
Improve transcription overlay fade-out animation

### DIFF
--- a/Sources/LookMaNoHands/Views/RecordingIndicator.swift
+++ b/Sources/LookMaNoHands/Views/RecordingIndicator.swift
@@ -560,8 +560,8 @@ class RecordingIndicatorWindowController: @unchecked Sendable {
 
         // Animate fade-out
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.15
-            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            context.duration = 0.35
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
             window.animator().alphaValue = 0.0
         }, completionHandler: {
             window.orderOut(nil)


### PR DESCRIPTION
## Summary
- Increases the recording indicator fade-out duration from 0.15s to 0.35s for a smoother dismissal
- Switches timing function from easeIn to easeOut, which is the correct curve for elements leaving the screen (starts fast, decelerates naturally)

## Test plan
- [ ] Trigger dictation and observe the overlay dismissal animation feels smooth and natural
- [ ] Verify the overlay window is fully removed after the fade completes