### PR TITLE
Hide processing indicator for fast transcriptions

### DIFF
--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1429,17 +1429,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         updateMenuBarIcon(isRecording: false)
 
         // DESIGN: Recording indicator hides immediately when recording stops.
-        // A processing indicator appears after 750ms if transcription is still running.
+        // A processing indicator appears after 1s if transcription is still running.
         // This makes short dictations feel instant while giving feedback for longer ones.
         recordingIndicator.hide()
 
-        // Schedule processing indicator to appear after 750ms (avoids flash for fast transcriptions)
+        // Schedule processing indicator to appear after 1s (avoids showing for fast transcriptions)
         pendingProcessingIndicator?.cancel()
         let processingWorkItem = DispatchWorkItem { [weak self] in
             self?.recordingIndicator.showProcessing()
         }
         pendingProcessingIndicator = processingWorkItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: processingWorkItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: processingWorkItem)
 
         // Resume system media if we paused it
         if Settings.shared.pauseMediaDuringDictation {


### PR DESCRIPTION
## Summary
- Increase the delay before showing the "Transcribing..." processing overlay from 750ms to 1 second
- Transcriptions that complete within 1 second now feel instant with no visible processing state
- The fade-out animation improvement from issue #349 was already shipped in PR #350

Closes #349

## Test plan
- [ ] Short dictation (1-2 words): processing indicator should not appear
- [ ] Long dictation (several sentences): processing indicator should appear after 1s if still transcribing
- [ ] Confirm fade-out animation still works smoothly when the indicator does appear
- [ ] `swift build -c release` passes