### PR TITLE
Add meeting app detection for Zoom, Teams, and Google Meet

### DIFF
--- a/Sources/LookMaNoHands/Models/LiveMeetingState.swift
+++ b/Sources/LookMaNoHands/Models/LiveMeetingState.swift
@@ -65,6 +65,10 @@ class LiveMeetingState: @unchecked Sendable {
     var frequencyBands: [Float] = Array(repeating: 0.0, count: 40)
     var isActive = true
 
+    // Meeting app detection
+    var detectedMeetingApp: MeetingApp? = nil
+    var detectedParticipants: [String] = []
+
     // User notes (inline note-taking during recording)
     var userNotes: [UserNote] = [] {
         didSet { isTimelineDirty = true }

--- a/Sources/LookMaNoHands/Models/MeetingApp.swift
+++ b/Sources/LookMaNoHands/Models/MeetingApp.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Identifies a supported video conferencing application for meeting app integration
+enum MeetingApp: String, Sendable, CaseIterable, Codable {
+    case zoom
+    case teams
+    case googleMeet
+
+    var displayName: String {
+        switch self {
+        case .zoom: return "Zoom"
+        case .teams: return "Microsoft Teams"
+        case .googleMeet: return "Google Meet"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .zoom: return "video.fill"
+        case .teams: return "person.3.fill"
+        case .googleMeet: return "globe"
+        }
+    }
+
+    /// Bundle IDs that identify this native app
+    var bundleIDs: Set<String> {
+        switch self {
+        case .zoom: return ["us.zoom.xos"]
+        case .teams: return ["com.microsoft.teams", "com.microsoft.teams2"]
+        case .googleMeet: return []  // Browser-based, detected via window title
+        }
+    }
+
+    /// Bundle IDs for browsers that may host Google Meet
+    static let browserBundleIDs: Set<String> = [
+        "com.google.Chrome",
+        "com.apple.Safari",
+        "com.microsoft.edgemac",
+        "com.brave.Browser",
+        "org.mozilla.firefox",
+        "company.thebrowser.Browser",  // Arc
+    ]
+
+    /// All native meeting app bundle IDs across all cases
+    static let allNativeBundleIDs: Set<String> = {
+        var ids = Set<String>()
+        for app in MeetingApp.allCases {
+            ids.formUnion(app.bundleIDs)
+        }
+        return ids
+    }()
+}

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -298,6 +298,7 @@ Now produce the complete meeting notes following the format above. Ensure every 
         static let autoSaveNotes = "autoSaveNotes"
         static let autoSaveFolder = "autoSaveFolder"
         static let speakerDiarizationEnabled = "speakerDiarizationEnabled"
+        static let meetingAppDetectionEnabled = "meetingAppDetectionEnabled"
     }
 
     // MARK: - File Paths
@@ -507,6 +508,13 @@ Now produce the complete meeting notes following the format above. Ensure every 
         }
     }
 
+    /// Whether to detect active meeting apps (Zoom, Teams, Meet) and extract participant names
+    @Published var meetingAppDetectionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(meetingAppDetectionEnabled, forKey: Keys.meetingAppDetectionEnabled)
+        }
+    }
+
     /// SHA of an update the user chose to skip (suppresses auto-check notifications)
     var skippedUpdateSHA: String? {
         get { UserDefaults.standard.string(forKey: Keys.skippedUpdateSHA) }
@@ -645,6 +653,9 @@ Now produce the complete meeting notes following the format above. Ensure every 
         } else {
             self.speakerDiarizationEnabled = true
         }
+
+        // Meeting app detection defaults to false (opt-in)
+        self.meetingAppDetectionEnabled = UserDefaults.standard.bool(forKey: Keys.meetingAppDetectionEnabled)
 
         // Auto-save notes defaults to false (opt-in)
         self.autoSaveNotes = UserDefaults.standard.bool(forKey: Keys.autoSaveNotes)
@@ -833,5 +844,6 @@ Now produce the complete meeting notes following the format above. Ensure every 
         autoSaveNotes = false
         autoSaveFolder = Settings.defaultAutoSaveFolder
         speakerDiarizationEnabled = true
+        meetingAppDetectionEnabled = false
     }
 }

--- a/Sources/LookMaNoHands/Services/MeetingAppDetector.swift
+++ b/Sources/LookMaNoHands/Services/MeetingAppDetector.swift
@@ -1,0 +1,377 @@
+import Foundation
+import AppKit
+import ApplicationServices
+
+/// Detects active video conferencing apps and extracts participant names
+/// from their accessibility trees during meeting recordings.
+@MainActor
+class MeetingAppDetector {
+
+    struct DetectionResult: Sendable {
+        let app: MeetingApp
+        let pid: pid_t
+        let windowTitle: String?
+        let participants: [String]
+    }
+
+    private var pollingTimer: Timer?
+
+    // MARK: - Pure Functions (Testable, nonisolated)
+
+    /// Match a bundle ID to a MeetingApp. Pure function for testability.
+    nonisolated static func matchBundleID(_ bundleID: String) -> MeetingApp? {
+        for app in MeetingApp.allCases {
+            if app.bundleIDs.contains(bundleID) {
+                return app
+            }
+        }
+        return nil
+    }
+
+    /// Check if a window title indicates a Google Meet session.
+    nonisolated static func isGoogleMeetTitle(_ title: String) -> Bool {
+        let lowered = title.lowercased()
+        return lowered.contains("meet.google.com") || lowered.contains("google meet")
+    }
+
+    /// Check if a window title suggests an active Zoom meeting.
+    nonisolated static func isZoomMeetingTitle(_ title: String) -> Bool {
+        let lowered = title.lowercased()
+        return lowered.contains("zoom meeting")
+            || lowered.contains("zoom webinar")
+            || lowered.hasPrefix("zoom")  // Zoom's main meeting window is titled "Zoom"
+    }
+
+    /// Check if a window title suggests an active Teams meeting/call.
+    nonisolated static func isTeamsMeetingTitle(_ title: String) -> Bool {
+        let lowered = title.lowercased()
+        return lowered.contains("meeting with")
+            || lowered.contains("| microsoft teams")
+            || lowered.contains("call with")
+    }
+
+    // MARK: - App Detection
+
+    /// One-shot scan: which meeting app is currently in an active meeting?
+    /// Checks native apps first (requiring meeting-active window titles), then browsers for Google Meet.
+    static func detectActiveMeetingApp() -> DetectionResult? {
+        let runningApps = NSWorkspace.shared.runningApplications
+
+        // Check native apps first (Zoom, Teams) -- require a meeting-active window title
+        for app in runningApps {
+            guard let bundleID = app.bundleIdentifier else { continue }
+            if let meetingApp = matchBundleID(bundleID) {
+                let titles = windowTitles(for: app.processIdentifier)
+                let activeMeetingTitle = titles.first { title in
+                    switch meetingApp {
+                    case .zoom: return isZoomMeetingTitle(title)
+                    case .teams: return isTeamsMeetingTitle(title)
+                    case .googleMeet: return false
+                    }
+                }
+                if let title = activeMeetingTitle {
+                    return DetectionResult(
+                        app: meetingApp,
+                        pid: app.processIdentifier,
+                        windowTitle: title,
+                        participants: []
+                    )
+                }
+            }
+        }
+
+        // Check browsers for Google Meet -- scan all windows, not just the first
+        for app in runningApps {
+            guard let bundleID = app.bundleIdentifier,
+                  MeetingApp.browserBundleIDs.contains(bundleID) else { continue }
+
+            let titles = windowTitles(for: app.processIdentifier)
+            if let meetTitle = titles.first(where: { isGoogleMeetTitle($0) }) {
+                return DetectionResult(
+                    app: .googleMeet,
+                    pid: app.processIdentifier,
+                    windowTitle: meetTitle,
+                    participants: []
+                )
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Participant Extraction
+
+    /// Extract participant names from the meeting app's accessibility tree.
+    /// Returns an empty array if extraction fails (graceful fallback).
+    func extractParticipants(for app: MeetingApp, pid: pid_t) -> [String] {
+        let appElement = AXUIElementCreateApplication(pid)
+
+        switch app {
+        case .zoom:
+            return extractZoomParticipants(appElement: appElement)
+        case .teams:
+            return extractTeamsParticipants(appElement: appElement)
+        case .googleMeet:
+            return extractGoogleMeetParticipants(appElement: appElement)
+        }
+    }
+
+    // MARK: - Polling
+
+    /// Start periodic polling for participant updates during recording.
+    func startPolling(interval: TimeInterval = 15, onChange: @escaping @MainActor (DetectionResult) -> Void) {
+        stopPolling()
+        pollingTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                guard let result = Self.detectActiveMeetingApp() else { return }
+                let participants = self.extractParticipants(for: result.app, pid: result.pid)
+                let updated = DetectionResult(
+                    app: result.app,
+                    pid: result.pid,
+                    windowTitle: result.windowTitle,
+                    participants: participants
+                )
+                onChange(updated)
+            }
+        }
+    }
+
+    /// Stop polling.
+    func stopPolling() {
+        pollingTimer?.invalidate()
+        pollingTimer = nil
+    }
+
+    // MARK: - Accessibility Helpers
+
+    /// Get the titles of all windows for a given process.
+    private static func windowTitles(for pid: pid_t) -> [String] {
+        let appElement = AXUIElementCreateApplication(pid)
+
+        var windowsRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXWindowsAttribute as CFString,
+            &windowsRef
+        )
+
+        guard result == .success,
+              let windows = windowsRef as? [AXUIElement] else {
+            return []
+        }
+
+        var titles: [String] = []
+        for window in windows {
+            var titleRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
+               let title = titleRef as? String,
+               !title.isEmpty {
+                titles.append(title)
+            }
+        }
+        return titles
+    }
+
+    /// Recursively collect all AXStaticText values from an element's subtree,
+    /// up to a maximum depth to avoid runaway traversal.
+    private func collectStaticTextValues(
+        from element: AXUIElement,
+        maxDepth: Int = 6,
+        currentDepth: Int = 0
+    ) -> [String] {
+        guard currentDepth < maxDepth else { return [] }
+
+        var results: [String] = []
+
+        // Check if this element is a static text with a value
+        var roleRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef) == .success,
+           let role = roleRef as? String,
+           role == "AXStaticText" || role == kAXStaticTextRole as String {
+            var valueRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success,
+               let value = valueRef as? String,
+               !value.trimmingCharacters(in: .whitespaces).isEmpty {
+                results.append(value.trimmingCharacters(in: .whitespaces))
+            }
+        }
+
+        // Recurse into children
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement] else {
+            return results
+        }
+
+        for child in children {
+            results.append(contentsOf: collectStaticTextValues(
+                from: child,
+                maxDepth: maxDepth,
+                currentDepth: currentDepth + 1
+            ))
+        }
+
+        return results
+    }
+
+    /// Find a child element matching a given role.
+    private func findChildWithRole(_ role: String, in element: AXUIElement) -> AXUIElement? {
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement] else {
+            return nil
+        }
+
+        for child in children {
+            var roleRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(child, kAXRoleAttribute as CFString, &roleRef) == .success,
+               let childRole = roleRef as? String,
+               childRole == role {
+                return child
+            }
+        }
+        return nil
+    }
+
+    /// Find all child elements matching a given role.
+    private func findChildrenWithRole(_ role: String, in element: AXUIElement) -> [AXUIElement] {
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement] else {
+            return []
+        }
+
+        return children.filter { child in
+            var roleRef: CFTypeRef?
+            return AXUIElementCopyAttributeValue(child, kAXRoleAttribute as CFString, &roleRef) == .success
+                && (roleRef as? String) == role
+        }
+    }
+
+    // MARK: - App-Specific Extraction
+
+    /// Extract participant names from Zoom's participant panel.
+    /// Zoom's participant list uses AXList > AXGroup > AXStaticText hierarchy.
+    private func extractZoomParticipants(appElement: AXUIElement) -> [String] {
+        // Get all windows and look for the participants panel
+        var windowsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+              let windows = windowsRef as? [AXUIElement] else {
+            return []
+        }
+
+        var names: [String] = []
+        for window in windows {
+            // Look for AXList elements (participant list panels)
+            let lists = findChildrenWithRole("AXList", in: window)
+            for list in lists {
+                let texts = collectStaticTextValues(from: list, maxDepth: 4)
+                names.append(contentsOf: texts)
+            }
+
+            // Also check AXGroup > AXList pattern (Zoom sometimes nests differently)
+            let groups = findChildrenWithRole("AXGroup", in: window)
+            for group in groups {
+                let lists = findChildrenWithRole("AXList", in: group)
+                for list in lists {
+                    let texts = collectStaticTextValues(from: list, maxDepth: 4)
+                    names.append(contentsOf: texts)
+                }
+            }
+        }
+
+        return filterParticipantNames(names)
+    }
+
+    /// Extract participant names from Microsoft Teams' roster panel.
+    private func extractTeamsParticipants(appElement: AXUIElement) -> [String] {
+        var windowsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+              let windows = windowsRef as? [AXUIElement] else {
+            return []
+        }
+
+        var names: [String] = []
+        for window in windows {
+            // Teams uses AXList for its people/roster panel
+            let lists = findChildrenWithRole("AXList", in: window)
+            for list in lists {
+                let texts = collectStaticTextValues(from: list, maxDepth: 5)
+                names.append(contentsOf: texts)
+            }
+        }
+
+        return filterParticipantNames(names)
+    }
+
+    /// Extract participant names from Google Meet in a browser.
+    /// Looks for participant sidebar in the browser's accessibility tree.
+    private func extractGoogleMeetParticipants(appElement: AXUIElement) -> [String] {
+        var windowsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+              let windows = windowsRef as? [AXUIElement] else {
+            return []
+        }
+
+        var names: [String] = []
+        for window in windows {
+            // Check window title to find the Meet tab
+            var titleRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
+               let title = titleRef as? String,
+               Self.isGoogleMeetTitle(title) {
+                // Walk into the web content area looking for participant list
+                let texts = collectStaticTextValues(from: window, maxDepth: 8)
+                names.append(contentsOf: texts)
+            }
+        }
+
+        return filterParticipantNames(names)
+    }
+
+    // MARK: - Name Filtering
+
+    /// Filter extracted text values to likely participant names.
+    /// Removes UI labels, status text, duplicates, and very short/long strings.
+    private func filterParticipantNames(_ rawNames: [String]) -> [String] {
+        let uiLabels: Set<String> = [
+            "Mute", "Unmute", "mute", "unmute",
+            "Participants", "participants",
+            "Chat", "chat",
+            "More", "more",
+            "Leave", "leave",
+            "Host", "host", "Co-host", "co-host",
+            "Raise Hand", "Lower Hand",
+            "In this meeting", "In the meeting",
+            "People", "You",
+            "Share Screen", "Record",
+            "Reactions", "View",
+        ]
+
+        var seen = Set<String>()
+        var filtered: [String] = []
+
+        for name in rawNames {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Skip empty, too short, or too long
+            guard trimmed.count >= 2, trimmed.count <= 60 else { continue }
+
+            // Skip known UI labels
+            guard !uiLabels.contains(trimmed) else { continue }
+
+            // Skip strings that look like timestamps, numbers, or status text
+            if trimmed.allSatisfy({ $0.isNumber || $0 == ":" || $0 == " " }) { continue }
+
+            // Skip duplicates (case-insensitive)
+            let key = trimmed.lowercased()
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+
+            filtered.append(trimmed)
+        }
+
+        return filtered
+    }
+}

--- a/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
+++ b/Sources/LookMaNoHands/Views/MeetingRecordTab.swift
@@ -24,6 +24,7 @@ struct MeetingRecordTab: View {
     @State private var selectedType: MeetingType = .general
     @State private var timer: Timer?
     @State private var audioUpdateTimer: Timer?
+    private let meetingAppDetector = MeetingAppDetector()
     @State private var showClearConfirmation = false
     @State private var showTranscript = true
     @State private var scrollProxy: ScrollViewProxy?
@@ -69,6 +70,13 @@ struct MeetingRecordTab: View {
             typePicker
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
+
+            if let app = liveState.detectedMeetingApp {
+                Divider()
+                meetingAppIndicator(app: app)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 8)
+            }
 
             Divider()
 
@@ -194,6 +202,25 @@ struct MeetingRecordTab: View {
             .fixedSize()
             .disabled(liveState.isRecording)
 
+            Spacer()
+        }
+    }
+
+    // MARK: - Meeting App Indicator
+
+    private func meetingAppIndicator(app: MeetingApp) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: app.icon)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            Text(app.displayName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if !liveState.detectedParticipants.isEmpty {
+                Text("\(liveState.detectedParticipants.count) participant\(liveState.detectedParticipants.count == 1 ? "" : "s")")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
             Spacer()
         }
     }
@@ -826,6 +853,21 @@ struct MeetingRecordTab: View {
 
             startTimer()
             startAudioLevelUpdates()
+
+            // Detect active meeting app and extract participants
+            if Settings.shared.meetingAppDetectionEnabled {
+                if let result = MeetingAppDetector.detectActiveMeetingApp() {
+                    liveState.detectedMeetingApp = result.app
+                    let participants = meetingAppDetector.extractParticipants(for: result.app, pid: result.pid)
+                    liveState.detectedParticipants = participants
+                    Logger.shared.info("Meeting app detected: \(result.app.displayName) with \(participants.count) participant(s)", category: .transcription)
+
+                    // Poll for participant updates during recording
+                    meetingAppDetector.startPolling(interval: 15) { [liveState] updated in
+                        liveState.detectedParticipants = updated.participants
+                    }
+                }
+            }
         } catch {
             liveState.statusMessage = "Failed to start: \(error.localizedDescription)"
             liveState.status = .ready
@@ -836,6 +878,7 @@ struct MeetingRecordTab: View {
         liveState.status = .processing
         liveState.statusMessage = "Finalizing transcription..."
 
+        meetingAppDetector.stopPolling()
         stopTimer()
         stopAudioLevelUpdates()
 

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -567,6 +567,18 @@ struct SettingsView: View {
                 }
             }
 
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Meeting App Detection")
+                    .font(.headline)
+
+                Toggle("Detect active meeting apps (Zoom, Teams, Meet)", isOn: $settings.meetingAppDetectionEnabled)
+                    .toggleStyle(.checkbox)
+
+                Text("When enabled, the app detects if a video call is active and shows the app name and participant count during recording.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Spacer()
         }
     }

--- a/Tests/LookMaNoHandsTests/MeetingAppDetectorTests.swift
+++ b/Tests/LookMaNoHandsTests/MeetingAppDetectorTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import LookMaNoHands
+
+// MARK: - Bundle ID matching
+
+final class MeetingAppBundleIDTests: XCTestCase {
+
+    func testZoomBundleIDMatches() {
+        XCTAssertEqual(MeetingAppDetector.matchBundleID("us.zoom.xos"), .zoom)
+    }
+
+    func testTeamsBundleIDMatches() {
+        XCTAssertEqual(MeetingAppDetector.matchBundleID("com.microsoft.teams2"), .teams)
+    }
+
+    func testClassicTeamsBundleIDMatches() {
+        XCTAssertEqual(MeetingAppDetector.matchBundleID("com.microsoft.teams"), .teams)
+    }
+
+    func testUnknownBundleIDReturnsNil() {
+        XCTAssertNil(MeetingAppDetector.matchBundleID("com.apple.Safari"))
+    }
+
+    func testEmptyBundleIDReturnsNil() {
+        XCTAssertNil(MeetingAppDetector.matchBundleID(""))
+    }
+
+    func testBrowserBundleIDAloneDoesNotMatch() {
+        // Browser bundle IDs should not match any native meeting app
+        XCTAssertNil(MeetingAppDetector.matchBundleID("com.google.Chrome"))
+        XCTAssertNil(MeetingAppDetector.matchBundleID("com.brave.Browser"))
+        XCTAssertNil(MeetingAppDetector.matchBundleID("company.thebrowser.Browser"))
+    }
+}
+
+// MARK: - Google Meet window title detection
+
+final class GoogleMeetTitleTests: XCTestCase {
+
+    func testMeetURLInTitle() {
+        XCTAssertTrue(MeetingAppDetector.isGoogleMeetTitle("meet.google.com/abc-defg-hij - Google Chrome"))
+    }
+
+    func testGoogleMeetNameInTitle() {
+        XCTAssertTrue(MeetingAppDetector.isGoogleMeetTitle("Team Standup - Google Meet"))
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertTrue(MeetingAppDetector.isGoogleMeetTitle("MEET.GOOGLE.COM/xyz"))
+    }
+
+    func testNonMeetTitle() {
+        XCTAssertFalse(MeetingAppDetector.isGoogleMeetTitle("Gmail - Google Chrome"))
+    }
+
+    func testEmptyTitle() {
+        XCTAssertFalse(MeetingAppDetector.isGoogleMeetTitle(""))
+    }
+
+    func testGoogleDocsNotMeet() {
+        XCTAssertFalse(MeetingAppDetector.isGoogleMeetTitle("Untitled Document - Google Docs"))
+    }
+}
+
+// MARK: - Zoom meeting title detection
+
+final class ZoomMeetingTitleTests: XCTestCase {
+
+    func testZoomMeetingTitle() {
+        XCTAssertTrue(MeetingAppDetector.isZoomMeetingTitle("Zoom Meeting"))
+    }
+
+    func testZoomWebinarTitle() {
+        XCTAssertTrue(MeetingAppDetector.isZoomMeetingTitle("Zoom Webinar"))
+    }
+
+    func testZoomMainWindow() {
+        XCTAssertTrue(MeetingAppDetector.isZoomMeetingTitle("Zoom"))
+    }
+
+    func testNonMeetingZoomTitle() {
+        XCTAssertFalse(MeetingAppDetector.isZoomMeetingTitle("Settings"))
+    }
+
+    func testEmptyZoomTitle() {
+        XCTAssertFalse(MeetingAppDetector.isZoomMeetingTitle(""))
+    }
+}
+
+// MARK: - Teams meeting title detection
+
+final class TeamsMeetingTitleTests: XCTestCase {
+
+    func testTeamsMeetingWithTitle() {
+        XCTAssertTrue(MeetingAppDetector.isTeamsMeetingTitle("Meeting with John | Microsoft Teams"))
+    }
+
+    func testTeamsCallWithTitle() {
+        XCTAssertTrue(MeetingAppDetector.isTeamsMeetingTitle("Call with Engineering"))
+    }
+
+    func testTeamsNonMeetingTitle() {
+        XCTAssertFalse(MeetingAppDetector.isTeamsMeetingTitle("Chat - Microsoft Teams"))
+    }
+
+    func testEmptyTeamsTitle() {
+        XCTAssertFalse(MeetingAppDetector.isTeamsMeetingTitle(""))
+    }
+}
+
+// MARK: - MeetingApp model
+
+final class MeetingAppModelTests: XCTestCase {
+
+    func testAllCasesHaveDisplayNames() {
+        for app in MeetingApp.allCases {
+            XCTAssertFalse(app.displayName.isEmpty, "\(app) has empty displayName")
+        }
+    }
+
+    func testAllCasesHaveIcons() {
+        for app in MeetingApp.allCases {
+            XCTAssertFalse(app.icon.isEmpty, "\(app) has empty icon")
+        }
+    }
+
+    func testCodableRoundTrip() throws {
+        for app in MeetingApp.allCases {
+            let data = try JSONEncoder().encode(app)
+            let decoded = try JSONDecoder().decode(MeetingApp.self, from: data)
+            XCTAssertEqual(decoded, app)
+        }
+    }
+
+    func testZoomHasNativeBundleIDs() {
+        XCTAssertFalse(MeetingApp.zoom.bundleIDs.isEmpty)
+        XCTAssertTrue(MeetingApp.zoom.bundleIDs.contains("us.zoom.xos"))
+    }
+
+    func testTeamsHasNativeBundleIDs() {
+        XCTAssertFalse(MeetingApp.teams.bundleIDs.isEmpty)
+        XCTAssertTrue(MeetingApp.teams.bundleIDs.contains("com.microsoft.teams2"))
+    }
+
+    func testGoogleMeetHasNoBundleIDs() {
+        XCTAssertTrue(MeetingApp.googleMeet.bundleIDs.isEmpty)
+    }
+
+    func testBrowserBundleIDsNotEmpty() {
+        XCTAssertFalse(MeetingApp.browserBundleIDs.isEmpty)
+        XCTAssertTrue(MeetingApp.browserBundleIDs.contains("com.google.Chrome"))
+    }
+
+    func testAllNativeBundleIDsAggregation() {
+        let allIDs = MeetingApp.allNativeBundleIDs
+        XCTAssertTrue(allIDs.contains("us.zoom.xos"))
+        XCTAssertTrue(allIDs.contains("com.microsoft.teams"))
+        XCTAssertTrue(allIDs.contains("com.microsoft.teams2"))
+        // Browser IDs should not be in native bundle IDs
+        XCTAssertFalse(allIDs.contains("com.google.Chrome"))
+    }
+}


### PR DESCRIPTION
## Summary

Detects active video conferencing apps (Zoom, Teams, Google Meet) during meeting recordings using accessibility APIs. Shows a subtle indicator in the recording tab with the app name and participant count. Participants are extracted from app UI trees and polled every 15 seconds. The feature is opt-in via a new `meetingAppDetectionEnabled` setting.

Key design decisions:
- `@MainActor` isolation on `MeetingAppDetector` for thread-safe timer/state access
- Native apps (Zoom, Teams) require meeting-active window titles to avoid false positives when the app is running idle
- Google Meet detection scans all browser windows, not just the frontmost
- Pure static functions (`matchBundleID`, `isGoogleMeetTitle`, etc.) are `nonisolated` for testability

## New files
- `MeetingApp.swift` -- enum model with bundle IDs, display names, icons
- `MeetingAppDetector.swift` -- detection, participant extraction, polling
- `MeetingAppDetectorTests.swift` -- 23 tests covering bundle ID matching, title detection, model properties

## Test plan
- [x] All 170 tests pass (`swift test`)
- [x] Build succeeds (`swift build -c release`)
- [ ] Manual: enable setting, start recording with Zoom/Teams/Meet active, verify indicator appears
- [ ] Manual: verify indicator does not appear when Zoom is open but not in a meeting