### PR TITLE
Bump WhisperKit to 1.0.0 (with breaking API fixes)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Verify WhisperKit revision
         run: |
-          EXPECTED_REV="26577ce3017aae8c9edfd9a0dd17851bd248c731"
+          EXPECTED_REV="25c62997041c134b03ca82731ce2f6fd2cae1eb9"
           ACTUAL_REV=$(grep -A 5 '"identity" : "whisperkit"' Package.resolved | grep '"revision"' | cut -d'"' -f4)
 
           if [ "$ACTUAL_REV" != "$EXPECTED_REV" ]; then

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/argmaxinc/WhisperKit.git", exact: "0.17.0"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", exact: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1")
     ],
     targets: [

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -54,8 +54,7 @@ class WhisperService: @unchecked Sendable {
         let computeOptions = ModelComputeOptions(
             melCompute: .cpuAndGPU,
             audioEncoderCompute: .cpuAndNeuralEngine,
-            textDecoderCompute: .cpuAndNeuralEngine,
-            prefillCompute: .cpuAndNeuralEngine
+            textDecoderCompute: .cpuAndNeuralEngine
         )
 
         // When the model is already downloaded, load from the local folder directly.
@@ -170,7 +169,7 @@ class WhisperService: @unchecked Sendable {
         // Log granular timing breakdown from WhisperKit
         if let timings = results.first?.timings {
             let ttft = timings.firstTokenTime - timings.pipelineStart
-            Logger.shared.info("📊 WhisperKit timings: encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, prefill=\(String(format: "%.3f", timings.prefill))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond)), RTF=\(String(format: "%.3f", timings.realTimeFactor))", category: .transcription)
+            Logger.shared.info("📊 WhisperKit timings: encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond)), RTF=\(String(format: "%.3f", timings.realTimeFactor))", category: .transcription)
         }
 
         let text = results.map { $0.text }.joined(separator: " ")
@@ -186,7 +185,7 @@ class WhisperService: @unchecked Sendable {
             // Log fallback timings
             if let timings = fallbackResults.first?.timings {
                 let ttft = timings.firstTokenTime - timings.pipelineStart
-                Logger.shared.info("📊 WhisperKit timings (fallback): encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, prefill=\(String(format: "%.3f", timings.prefill))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond))", category: .transcription)
+                Logger.shared.info("📊 WhisperKit timings (fallback): encoding=\(String(format: "%.3f", timings.encoding))s, decoding=\(String(format: "%.3f", timings.decodingPredictions))s, logmels=\(String(format: "%.3f", timings.logmels))s, TTFT=\(String(format: "%.3f", ttft))s, tok/s=\(String(format: "%.1f", timings.tokensPerSecond))", category: .transcription)
             }
 
             let fallbackText = fallbackResults.map { $0.text }.joined(separator: " ")


### PR DESCRIPTION
## Summary

- Bumps WhisperKit from 0.17.0 to 1.0.0 (the Argmax Open-Source SDK graduation release)
- Fixes two breaking API removals that would have caused a build failure if dependabot's PR #361 was merged as-is

## Breaking changes addressed

| Removed API | Our usage | Fix |
|-------------|-----------|-----|
| `ModelComputeOptions.prefillCompute` | `WhisperService.swift:58` | Removed the argument |
| `TranscriptionTimings.prefill` | `WhisperService.swift:173,189` | Removed from log strings |

**Note on `prefill` removal:** The dropped `prefill=X` log field is intentional log-data loss, not a compute regression. WhisperKit 1.0.0 removed both the `prefillCompute` configuration knob and the corresponding `TranscriptionTimings.prefill` field from its public API; the prefill stage is now folded into `firstTokenTime` (TTFT), which we already log.

## Test results

Tested locally against the deployed build:
- Model load (small): ~1s, no Hub hang
- Neural Engine warmup: both passes in 0.61s
- Dictation RTF: 0.08–0.11x (well under real-time)
- Full pipeline: ~1.1s for 13s audio
- SpeakerKit diarization: ran and completed successfully
- No errors or crashes

## CI

- Updated `.github/workflows/security.yml` pinned WhisperKit revision hash from the 0.17.0 commit (`26577ce…`) to the 1.0.0 commit (`25c6299…`) so the `Verify Package.resolved Integrity` job passes.

Closes #361