### PR TITLE
Fix large-v3-turbo download by resolving canonical HF model name

### DIFF
--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -57,13 +57,16 @@ class WhisperService: @unchecked Sendable {
             textDecoderCompute: .cpuAndNeuralEngine
         )
 
+        // Resolve the canonical HF directory name for this model (handles large-v3-turbo naming mismatch).
+        let resolvedName = await Self.resolveCanonicalModelName(modelName, in: cacheDir)
+
         // When the model is already downloaded, load from the local folder directly.
         // This avoids a HuggingFace Hub network call (hubApi.snapshot) that can hang
         // during macOS-initiated relaunches (e.g., after granting screen recording permission).
-        let localModelFolder: String? = Self.localModelPath(named: modelName, in: cacheDir)
+        let localModelFolder: String? = Self.localModelPath(named: resolvedName, in: cacheDir)
 
         let config = WhisperKitConfig(
-            model: modelName,
+            model: resolvedName,
             downloadBase: cacheDir,
             modelFolder: localModelFolder,
             computeOptions: computeOptions,
@@ -86,7 +89,7 @@ class WhisperService: @unchecked Sendable {
                 // Local load failed — retry with Hub download in case files are corrupted
                 Logger.shared.info("Retrying with Hub download...", category: .whisper)
                 let retryConfig = WhisperKitConfig(
-                    model: modelName,
+                    model: resolvedName,
                     downloadBase: cacheDir,
                     computeOptions: computeOptions,
                     verbose: false,
@@ -296,7 +299,7 @@ class WhisperService: @unchecked Sendable {
     // MARK: - Model Management
 
     /// Returns the local model folder path if the model is already downloaded, or nil.
-    /// Used by `loadModel` to bypass HuggingFace Hub network calls when loading cached models.
+    /// Callers must pass the canonical (resolved) model name, not the user-facing raw value.
     private static func localModelPath(named modelName: String, in cacheDir: URL) -> String? {
         let modelDir = cacheDir
             .appendingPathComponent("models")
@@ -308,6 +311,58 @@ class WhisperService: @unchecked Sendable {
         return modelDir.path
     }
 
+    /// Scan the cache for a downloaded turbo model directory, returning the variant name
+    /// (without the `openai_whisper-` prefix) or nil.  Local-only — no network call.
+    private static func scanCacheForTurboVariant(in cacheDir: URL) -> String? {
+        let parent = cacheDir
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: parent.path) else {
+            return nil
+        }
+
+        if let dir = entries.first(where: { name in
+            let lower = name.lowercased()
+            return lower.hasPrefix("openai_whisper-") && lower.contains("large-v3") && lower.contains("turbo")
+        }) {
+            return dir.replacingOccurrences(of: "openai_whisper-", with: "")
+        }
+        return nil
+    }
+
+    /// Maps a user-facing model name to the canonical HuggingFace directory name (minus the
+    /// `openai_whisper-` prefix).  The `large-v3-turbo` short name does not appear verbatim
+    /// in `argmaxinc/whisperkit-coreml` — actual directories use device-quantized names like
+    /// `large-v3-v20240930_turbo_632MB`.  Resolution order:
+    ///
+    /// 1. Fast path — non-turbo names match HF dirs directly; return as-is.
+    /// 2. Local cache scan — offline-safe, picks up the actual downloaded dir name.
+    /// 3. WhisperKit remote config — `recommendedRemoteModels()` returns per-device canonical names.
+    /// 4. Fallback — return the raw name (preserves prior behaviour for unknown models).
+    static func resolveCanonicalModelName(_ modelName: String, in cacheDir: URL) async -> String {
+        guard modelName.contains("turbo") else { return modelName }
+
+        if let cached = scanCacheForTurboVariant(in: cacheDir) {
+            Logger.shared.info("Resolved '\(modelName)' from local cache: \(cached)", category: .whisper)
+            return cached
+        }
+
+        let support = await WhisperKit.recommendedRemoteModels()
+        if let match = support.supported.first(where: { name in
+            let lower = name.lowercased()
+            return lower.contains("large-v3") && lower.contains("turbo")
+        }) {
+            let variant = match.replacingOccurrences(of: "openai_whisper-", with: "")
+            Logger.shared.info("Resolved '\(modelName)' from remote config: \(variant)", category: .whisper)
+            return variant
+        }
+
+        Logger.shared.warning("Could not resolve canonical name for '\(modelName)' — using raw value", category: .whisper)
+        return modelName
+    }
+
     /// Check if a WhisperKit model is available in the cache.
     /// Models are downloaded to ~/Library/Caches/models/argmaxinc/whisperkit-coreml/
     ///
@@ -317,7 +372,15 @@ class WhisperService: @unchecked Sendable {
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             return false
         }
-        return localModelPath(named: modelName, in: cacheDir) != nil
+        // Direct path check covers tiny/base/small/medium.
+        if localModelPath(named: modelName, in: cacheDir) != nil { return true }
+        // For turbo models, the cached dir name differs from the user-facing rawValue.
+        if modelName.contains("turbo"),
+           let variant = scanCacheForTurboVariant(in: cacheDir),
+           localModelPath(named: variant, in: cacheDir) != nil {
+            return true
+        }
+        return false
     }
 
     /// Get available WhisperKit models to download
@@ -330,7 +393,6 @@ class WhisperService: @unchecked Sendable {
             ("large-v3-turbo", "~600 MB", "Best accuracy (recommended for meetings)")
         ]
     }
-
 
     /// Download a model from Hugging Face.
     ///
@@ -354,8 +416,13 @@ class WhisperService: @unchecked Sendable {
             throw WhisperError.downloadFailed("Could not access caches directory")
         }
 
+        // Resolve canonical HF directory name before handing to WhisperKit.
+        // "large-v3-turbo" does not appear in any argmaxinc/whisperkit-coreml directory name;
+        // the actual dirs use versioned names like `large-v3-v20240930_turbo`.
+        let resolvedName = await resolveCanonicalModelName(modelName, in: cacheDir)
+
         let config = WhisperKitConfig(
-            model: modelName,
+            model: resolvedName,
             downloadBase: cacheDir,
             verbose: true,
             logLevel: .info

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -350,7 +350,10 @@ class WhisperService: @unchecked Sendable {
         }
 
         let support = await WhisperKit.recommendedRemoteModels()
-        if let match = support.supported.first(where: { name in
+        // Search supported first, then disabled (models known to WhisperKit but not recommended
+        // for this device class — e.g. turbo models on M1 Macs are in disabled, not supported).
+        let allKnown = support.supported + support.disabled
+        if let match = allKnown.first(where: { name in
             let lower = name.lowercased()
             return lower.contains("large-v3") && lower.contains("turbo")
         }) {

--- a/Sources/LookMaNoHands/Services/WhisperService.swift
+++ b/Sources/LookMaNoHands/Services/WhisperService.swift
@@ -311,9 +311,26 @@ class WhisperService: @unchecked Sendable {
         return modelDir.path
     }
 
-    /// Scan the cache for a downloaded turbo model directory, returning the variant name
+    /// User-facing model names that do not match HuggingFace directory names verbatim
+    /// and require canonical-name resolution.  Currently only `large-v3-turbo`: HF dirs
+    /// use device-quantized names like `large-v3-v20240930_turbo_632MB`.
+    static let aliasedModelNames: Set<String> = ["large-v3-turbo"]
+
+    /// Substrings used to match a user-facing aliased name against an HF directory name.
+    /// Returns the substrings that must all be present (lowercased) in a candidate dir name.
+    private static func cacheMatchTokens(for modelName: String) -> [String] {
+        // `large-v3-turbo` → ["large-v3", "turbo"]
+        // Splits on "-turbo" suffix to allow versioned dirs like `large-v3-v20240930_turbo`.
+        let lower = modelName.lowercased()
+        if lower.hasSuffix("-turbo") {
+            return [String(lower.dropLast("-turbo".count)), "turbo"]
+        }
+        return [lower]
+    }
+
+    /// Scan the cache for a downloaded aliased model directory, returning the variant name
     /// (without the `openai_whisper-` prefix) or nil.  Local-only — no network call.
-    private static func scanCacheForTurboVariant(in cacheDir: URL) -> String? {
+    static func scanCacheForAliasedVariant(_ modelName: String, in cacheDir: URL) -> String? {
         let parent = cacheDir
             .appendingPathComponent("models")
             .appendingPathComponent("argmaxinc")
@@ -323,9 +340,11 @@ class WhisperService: @unchecked Sendable {
             return nil
         }
 
+        let tokens = cacheMatchTokens(for: modelName)
         if let dir = entries.first(where: { name in
             let lower = name.lowercased()
-            return lower.hasPrefix("openai_whisper-") && lower.contains("large-v3") && lower.contains("turbo")
+            guard lower.hasPrefix("openai_whisper-") else { return false }
+            return tokens.allSatisfy { lower.contains($0) }
         }) {
             return dir.replacingOccurrences(of: "openai_whisper-", with: "")
         }
@@ -333,19 +352,17 @@ class WhisperService: @unchecked Sendable {
     }
 
     /// Maps a user-facing model name to the canonical HuggingFace directory name (minus the
-    /// `openai_whisper-` prefix).  The `large-v3-turbo` short name does not appear verbatim
-    /// in `argmaxinc/whisperkit-coreml` — actual directories use device-quantized names like
-    /// `large-v3-v20240930_turbo_632MB`.  Resolution order:
+    /// `openai_whisper-` prefix).  Only names in `aliasedModelNames` require resolution; all
+    /// others are returned as-is.  Resolution order for aliased names:
     ///
-    /// 1. Fast path — non-turbo names match HF dirs directly; return as-is.
-    /// 2. Local cache scan — offline-safe, picks up the actual downloaded dir name.
-    /// 3. WhisperKit remote config — `recommendedRemoteModels()` returns per-device canonical names.
-    /// 4. Fallback — return the raw name (preserves prior behaviour for unknown models).
+    /// 1. Local cache scan — offline-safe, picks up the actual downloaded dir name.
+    /// 2. WhisperKit remote config — `recommendedRemoteModels()` returns per-device canonical names.
+    /// 3. Fallback — return the raw name (preserves prior behaviour if both lookups fail).
     static func resolveCanonicalModelName(_ modelName: String, in cacheDir: URL) async -> String {
-        guard modelName.contains("turbo") else { return modelName }
+        guard aliasedModelNames.contains(modelName) else { return modelName }
 
-        if let cached = scanCacheForTurboVariant(in: cacheDir) {
-            Logger.shared.info("Resolved '\(modelName)' from local cache: \(cached)", category: .whisper)
+        if let cached = scanCacheForAliasedVariant(modelName, in: cacheDir) {
+            Logger.shared.debug("Resolved '\(modelName)' from local cache: \(cached)", category: .whisper)
             return cached
         }
 
@@ -353,12 +370,13 @@ class WhisperService: @unchecked Sendable {
         // Search supported first, then disabled (models known to WhisperKit but not recommended
         // for this device class — e.g. turbo models on M1 Macs are in disabled, not supported).
         let allKnown = support.supported + support.disabled
+        let tokens = cacheMatchTokens(for: modelName)
         if let match = allKnown.first(where: { name in
             let lower = name.lowercased()
-            return lower.contains("large-v3") && lower.contains("turbo")
+            return tokens.allSatisfy { lower.contains($0) }
         }) {
             let variant = match.replacingOccurrences(of: "openai_whisper-", with: "")
-            Logger.shared.info("Resolved '\(modelName)' from remote config: \(variant)", category: .whisper)
+            Logger.shared.debug("Resolved '\(modelName)' from remote config: \(variant)", category: .whisper)
             return variant
         }
 
@@ -375,11 +393,11 @@ class WhisperService: @unchecked Sendable {
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             return false
         }
-        // Direct path check covers tiny/base/small/medium.
+        // Direct path check covers names that match HF dirs verbatim (tiny/base/small/medium).
         if localModelPath(named: modelName, in: cacheDir) != nil { return true }
-        // For turbo models, the cached dir name differs from the user-facing rawValue.
-        if modelName.contains("turbo"),
-           let variant = scanCacheForTurboVariant(in: cacheDir),
+        // Aliased names (e.g. large-v3-turbo) cache under a versioned dir name.
+        if aliasedModelNames.contains(modelName),
+           let variant = scanCacheForAliasedVariant(modelName, in: cacheDir),
            localModelPath(named: variant, in: cacheDir) != nil {
             return true
         }

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -845,6 +845,12 @@ struct SettingsView: View {
                             Text(error)
                                 .font(.caption)
                                 .foregroundColor(.red)
+                            Button("Retry") {
+                                modelDownloadError = nil
+                                handleModelChange(to: settings.whisperModel)
+                            }
+                            .font(.caption)
+                            .buttonStyle(.borderless)
                         }
                     }
                 }

--- a/Tests/LookMaNoHandsTests/WhisperServiceTests.swift
+++ b/Tests/LookMaNoHandsTests/WhisperServiceTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import LookMaNoHands
+
+final class WhisperServiceTests: XCTestCase {
+
+    private var tempCacheDir: URL!
+    private var modelsParent: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempCacheDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WhisperServiceTests-\(UUID().uuidString)")
+        modelsParent = tempCacheDir
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+        try? FileManager.default.createDirectory(at: modelsParent, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempCacheDir)
+        super.tearDown()
+    }
+
+    private func createModelDir(_ name: String) {
+        let dir = modelsParent.appendingPathComponent(name)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - scanCacheForAliasedVariant
+
+    func testScanFindsVersionedTurboDirectory() {
+        createModelDir("openai_whisper-large-v3-v20240930_turbo_632MB")
+
+        let result = WhisperService.scanCacheForAliasedVariant("large-v3-turbo", in: tempCacheDir)
+
+        XCTAssertEqual(result, "large-v3-v20240930_turbo_632MB")
+    }
+
+    func testScanReturnsNilWhenNoMatchingDirectory() {
+        createModelDir("openai_whisper-base")
+        createModelDir("openai_whisper-small")
+
+        let result = WhisperService.scanCacheForAliasedVariant("large-v3-turbo", in: tempCacheDir)
+
+        XCTAssertNil(result)
+    }
+
+    func testScanReturnsNilWhenCacheDirectoryMissing() {
+        let missingDir = tempCacheDir.appendingPathComponent("does-not-exist")
+
+        let result = WhisperService.scanCacheForAliasedVariant("large-v3-turbo", in: missingDir)
+
+        XCTAssertNil(result)
+    }
+
+    func testScanIgnoresDirectoriesWithoutOpenAIPrefix() {
+        createModelDir("large-v3-turbo-stray")
+
+        let result = WhisperService.scanCacheForAliasedVariant("large-v3-turbo", in: tempCacheDir)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - resolveCanonicalModelName
+
+    func testResolveReturnsRawNameForNonAliasedModel() async {
+        let result = await WhisperService.resolveCanonicalModelName("base", in: tempCacheDir)
+        XCTAssertEqual(result, "base")
+    }
+
+    func testResolveDoesNotMatchSimilarNonAliasedName() async {
+        // Guards against weak `contains("turbo")` regression — names like
+        // "turbocharged-v1" must not trigger aliased resolution.
+        let result = await WhisperService.resolveCanonicalModelName("turbocharged-v1", in: tempCacheDir)
+        XCTAssertEqual(result, "turbocharged-v1")
+    }
+
+    func testResolveReturnsCachedVariantWhenAvailable() async {
+        createModelDir("openai_whisper-large-v3-v20240930_turbo_632MB")
+
+        let result = await WhisperService.resolveCanonicalModelName("large-v3-turbo", in: tempCacheDir)
+
+        XCTAssertEqual(result, "large-v3-v20240930_turbo_632MB")
+    }
+
+    func testAliasedModelNamesIncludesLargeV3Turbo() {
+        XCTAssertTrue(WhisperService.aliasedModelNames.contains("large-v3-turbo"))
+    }
+}


### PR DESCRIPTION
## Summary

- `large-v3-turbo` download always failed because the user-facing model name doesn't match any directory in `argmaxinc/whisperkit-coreml`. WhisperKit's glob `*large-v3-turbo/*` finds nothing — actual HF dirs use versioned names like `openai_whisper-large-v3_turbo_954MB`.
- Added `resolveCanonicalModelName()` to map the user-facing name to the correct HF directory before passing to WhisperKit. Resolution order: local cache scan (offline-safe) → `WhisperKit.recommendedRemoteModels()` searching both `supported` and `disabled` lists (the `disabled` search is required on M1 Macs, where turbo is absent from `supported` but present in the global known-model set).
- Updated `modelExists()` to detect cached turbo models via cache scan (previously always returned false for turbo, causing re-downloads on every launch).
- Added "Retry" button to Settings → Models download error state.

Note: PR #365 (already on main) handled the WhisperKit version bump from 0.14.1 → 1.0.0 described in issue #364's original plan. This PR completes the remaining name-resolution and UI work.

## Test plan

- [ ] Select "Large v3 Turbo" in Settings → Models → Download succeeds without error
- [ ] Restart app, re-select "Large v3 Turbo" — no re-download (loads from cache)
- [ ] Disable wifi, attempt download → error shows with "Retry" button; re-enable wifi, click Retry → download proceeds
- [ ] Other models (tiny/base/small/medium) unaffected — no change in behaviour
- [ ] `swift test` passes (141 tests)

Closes #362
Closes #364