### PR TITLE
Bump version to 1.6.0 (build 29)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.11</string>
+	<string>1.6.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Bump `CFBundleShortVersionString` → `1.6.0` and `CFBundleVersion` → `29`.

Merging main after PR #365 (WhisperKit 1.0.0) and PR #366 (large-v3-turbo fix).