### PR TITLE
Add sound effects and mute-while-recording options

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -33,6 +33,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     // System audio mute state — saved/restored around recording when muteWhileRecording is on
     private var savedMuteState: UInt32 = 0
     private var didMute = false
+    // The specific device that was muted; captured at mute time so restore targets the same device
+    // even if the user switches the default output device mid-recording.
+    private var mutedDeviceID: AudioDeviceID?
 
     // Popover for menu bar content (alternative to dropdown menu)
     private var popover: NSPopover?
@@ -1197,18 +1200,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             dev, &addr, 0, nil, UInt32(MemoryLayout<UInt32>.size), &muted)
         if status == noErr {
             didMute = true
+            mutedDeviceID = dev  // Remember which device was muted for accurate restore
         }
     }
 
-    /// Restores the saved mute state on the default output device.
+    /// Restores the saved mute state on the device that was muted.
+    /// Uses the stored mutedDeviceID rather than re-querying the default output device, so a
+    /// mid-recording device switch doesn't leave the original device stuck muted.
     /// Safe to call even when muting was skipped (idempotent via didMute guard).
     private func restoreSystemOutputMute() {
-        guard didMute, let dev = defaultOutputDeviceID() else { return }
+        guard didMute, let dev = mutedDeviceID else { return }
         var addr = mutePropertyAddress()
         var val = savedMuteState
         _ = AudioObjectSetPropertyData(
             dev, &addr, 0, nil, UInt32(MemoryLayout<UInt32>.size), &val)
         didMute = false
+        mutedDeviceID = nil
     }
 
     /// Start or stop recording (used by menu bar, URL scheme, and hotkey)
@@ -1366,8 +1373,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         // Show recording indicator
         recordingIndicator.show()
 
-        // Play start cue BEFORE AVAudioEngine starts — NSSound is silenced by the engine once active
-        playSoundCue(NSSound.Name(Settings.shared.dictationStartSound))
+        // Play start cue BEFORE AVAudioEngine starts — NSSound is silenced by the engine once active.
+        // Skip the start cue when mute-while-recording is on: muteSystemOutput() fires a few ms after
+        // NSSound.play() and would cut the cue off mid-play anyway, so playing it is pointless noise.
+        if !Settings.shared.muteWhileRecording {
+            playSoundCue(NSSound.Name(Settings.shared.dictationStartSound))
+        }
 
         // Start audio recording FIRST
         do {

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1372,7 +1372,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             print("Recording started")
 
             // Play start cue synchronously (guard is inside helper)
-            playSoundCue("Tink")
+            playSoundCue(NSSound.Name(Settings.shared.dictationStartSound))
 
             // Mute system output synchronously — must NOT be inside the delayed Task below,
             // because a short recording (quick double-tap / instant ESC) could restore the volume
@@ -1538,7 +1538,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         restoreSystemOutputMute()
 
         // Play stop cue
-        playSoundCue("Pop")
+        playSoundCue(NSSound.Name(Settings.shared.dictationStopSound))
 
         Logger.shared.info("📊 Pipeline started: \(audioSamples.count) samples (\(String(format: "%.1f", Double(audioSamples.count) / 16000.0))s audio)", category: .transcription)
 

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1366,13 +1366,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         // Show recording indicator
         recordingIndicator.show()
 
+        // Play start cue BEFORE AVAudioEngine starts — NSSound is silenced by the engine once active
+        playSoundCue(NSSound.Name(Settings.shared.dictationStartSound))
+
         // Start audio recording FIRST
         do {
             try audioRecorder.startRecording()
             print("Recording started")
-
-            // Play start cue synchronously (guard is inside helper)
-            playSoundCue(NSSound.Name(Settings.shared.dictationStartSound))
 
             // Mute system output synchronously — must NOT be inside the delayed Task below,
             // because a short recording (quick double-tap / instant ESC) could restore the volume

--- a/Sources/LookMaNoHands/App/AppDelegate.swift
+++ b/Sources/LookMaNoHands/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import AVFoundation
+import CoreAudio
 
 /// AppDelegate handles menu bar setup and application lifecycle
 /// This is where we configure the app to run as a menu bar app without a dock icon
@@ -28,6 +29,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     // Focused element before recording started (for restoring focus on cancel)
     private var focusedElementBeforeRecording: AXUIElement?
     private var cursorSnapshotBeforeRecording: CursorSnapshot?
+
+    // System audio mute state — saved/restored around recording when muteWhileRecording is on
+    private var savedMuteState: UInt32 = 0
+    private var didMute = false
 
     // Popover for menu bar content (alternative to dropdown menu)
     private var popover: NSPopover?
@@ -1138,6 +1143,74 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         startOrStopRecording()
     }
 
+    // MARK: - Sound cues
+
+    /// Play a named system sound if sound effects are enabled.
+    private func playSoundCue(_ name: NSSound.Name) {
+        guard Settings.shared.soundEffectsEnabled else { return }
+        NSSound(named: name)?.play()
+    }
+
+    // MARK: - System audio mute helpers
+
+    /// Returns the AudioDeviceID of the current default output device, or nil on error.
+    private func defaultOutputDeviceID() -> AudioDeviceID? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var devID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &devID)
+        return status == noErr ? devID : nil
+    }
+
+    /// The CoreAudio property address for the output mute control.
+    private func mutePropertyAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    /// Mutes the default output device and saves its prior mute state.
+    /// Skips silently if the device does not support the mute property or muting fails.
+    private func muteSystemOutput() {
+        guard Settings.shared.muteWhileRecording,
+              let dev = defaultOutputDeviceID() else { return }
+        var addr = mutePropertyAddress()
+
+        // Only proceed if the property is settable on this device
+        var settable: DarwinBoolean = false
+        guard AudioObjectIsPropertySettable(dev, &addr, &settable) == noErr,
+              settable.boolValue else { return }
+
+        // Save the current mute state so we can restore it precisely
+        var prior: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(dev, &addr, 0, nil, &size, &prior) == noErr else { return }
+        savedMuteState = prior
+
+        var muted: UInt32 = 1
+        let status = AudioObjectSetPropertyData(
+            dev, &addr, 0, nil, UInt32(MemoryLayout<UInt32>.size), &muted)
+        if status == noErr {
+            didMute = true
+        }
+    }
+
+    /// Restores the saved mute state on the default output device.
+    /// Safe to call even when muting was skipped (idempotent via didMute guard).
+    private func restoreSystemOutputMute() {
+        guard didMute, let dev = defaultOutputDeviceID() else { return }
+        var addr = mutePropertyAddress()
+        var val = savedMuteState
+        _ = AudioObjectSetPropertyData(
+            dev, &addr, 0, nil, UInt32(MemoryLayout<UInt32>.size), &val)
+        didMute = false
+    }
+
     /// Start or stop recording (used by menu bar, URL scheme, and hotkey)
     /// This method bypasses the hotkeyEnabled check - it's for manual user actions
     private func startOrStopRecording() {
@@ -1196,6 +1269,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             MusicPlayerController.shared.resumePreviouslyPlayingPlayers()
             mediaControlService.resumeMedia()
         }
+
+        // Restore system audio mute state if we muted it
+        restoreSystemOutputMute()
 
         NSLog("✅ Recording canceled - no text will be inserted")
     }
@@ -1295,6 +1371,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             try audioRecorder.startRecording()
             print("Recording started")
 
+            // Play start cue synchronously (guard is inside helper)
+            playSoundCue("Tink")
+
+            // Mute system output synchronously — must NOT be inside the delayed Task below,
+            // because a short recording (quick double-tap / instant ESC) could restore the volume
+            // before the delayed mute fires, leaving output stuck muted.
+            muteSystemOutput()
+
             // CRITICAL: Pause media AFTER starting AVAudioEngine (not before)
             // This ensures we re-pause even if AVAudioEngine.start() triggers a system event that resumes media
             if Settings.shared.pauseMediaDuringDictation {
@@ -1329,6 +1413,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
                 MusicPlayerController.shared.resumePreviouslyPlayingPlayers()
                 mediaControlService.resumeMedia()
             }
+
+            // Restore system audio mute state if we muted it
+            restoreSystemOutputMute()
 
             // Hide indicator with slight delay to ensure proper cleanup
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
@@ -1446,6 +1533,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
             MusicPlayerController.shared.resumePreviouslyPlayingPlayers()
             mediaControlService.resumeMedia()
         }
+
+        // Restore system audio mute state if we muted it
+        restoreSystemOutputMute()
+
+        // Play stop cue
+        playSoundCue("Pop")
 
         Logger.shared.info("📊 Pipeline started: \(audioSamples.count) samples (\(String(format: "%.1f", Double(audioSamples.count) / 16000.0))s audio)", category: .transcription)
 

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -288,6 +288,8 @@ Now produce the complete meeting notes following the format above. Ensure every 
         static let lastUpdateCheckDate = "lastUpdateCheckDate"
         static let skippedUpdateSHA = "skippedUpdateSHA"
         static let pauseMediaDuringDictation = "pauseMediaDuringDictation"
+        static let soundEffectsEnabled = "soundEffectsEnabled"
+        static let muteWhileRecording = "muteWhileRecording"
         static let hotkeyEnabled = "hotkeyEnabled"
         static let toggleHotkeyShortcut = "toggleHotkeyShortcut"
         static let meetingRetentionDays = "meetingRetentionDays"
@@ -430,6 +432,20 @@ Now produce the complete meeting notes following the format above. Ensure every 
     @Published var pauseMediaDuringDictation: Bool {
         didSet {
             UserDefaults.standard.set(pauseMediaDuringDictation, forKey: Keys.pauseMediaDuringDictation)
+        }
+    }
+
+    /// Whether to play a sound cue at dictation start and stop
+    @Published var soundEffectsEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(soundEffectsEnabled, forKey: Keys.soundEffectsEnabled)
+        }
+    }
+
+    /// Whether to mute system audio output during dictation to prevent speaker bleed
+    @Published var muteWhileRecording: Bool {
+        didSet {
+            UserDefaults.standard.set(muteWhileRecording, forKey: Keys.muteWhileRecording)
         }
     }
 
@@ -610,6 +626,20 @@ Now produce the complete meeting notes following the format above. Ensure every 
             self.pauseMediaDuringDictation = UserDefaults.standard.bool(forKey: Keys.pauseMediaDuringDictation)
         } else {
             self.pauseMediaDuringDictation = true
+        }
+
+        // Sound effects defaults to true (enabled by default)
+        if UserDefaults.standard.object(forKey: Keys.soundEffectsEnabled) != nil {
+            self.soundEffectsEnabled = UserDefaults.standard.bool(forKey: Keys.soundEffectsEnabled)
+        } else {
+            self.soundEffectsEnabled = true
+        }
+
+        // Mute while recording defaults to false (opt-in)
+        if UserDefaults.standard.object(forKey: Keys.muteWhileRecording) != nil {
+            self.muteWhileRecording = UserDefaults.standard.bool(forKey: Keys.muteWhileRecording)
+        } else {
+            self.muteWhileRecording = false
         }
 
         // Hotkey enabled defaults to true (enabled by default)
@@ -824,6 +854,8 @@ Now produce the complete meeting notes following the format above. Ensure every 
         lastUpdateCheckDate = nil
         skippedUpdateSHA = nil
         pauseMediaDuringDictation = true
+        soundEffectsEnabled = true
+        muteWhileRecording = false
         hotkeyEnabled = true
         toggleHotkeyShortcut = Hotkey(keyCode: 2, modifiers: .init(command: true, shift: true))
         meetingRetentionDays = 90

--- a/Sources/LookMaNoHands/Models/Settings.swift
+++ b/Sources/LookMaNoHands/Models/Settings.swift
@@ -289,6 +289,8 @@ Now produce the complete meeting notes following the format above. Ensure every 
         static let skippedUpdateSHA = "skippedUpdateSHA"
         static let pauseMediaDuringDictation = "pauseMediaDuringDictation"
         static let soundEffectsEnabled = "soundEffectsEnabled"
+        static let dictationStartSound = "dictationStartSound"
+        static let dictationStopSound = "dictationStopSound"
         static let muteWhileRecording = "muteWhileRecording"
         static let hotkeyEnabled = "hotkeyEnabled"
         static let toggleHotkeyShortcut = "toggleHotkeyShortcut"
@@ -439,6 +441,20 @@ Now produce the complete meeting notes following the format above. Ensure every 
     @Published var soundEffectsEnabled: Bool {
         didSet {
             UserDefaults.standard.set(soundEffectsEnabled, forKey: Keys.soundEffectsEnabled)
+        }
+    }
+
+    /// Name of the NSSound to play when dictation starts
+    @Published var dictationStartSound: String {
+        didSet {
+            UserDefaults.standard.set(dictationStartSound, forKey: Keys.dictationStartSound)
+        }
+    }
+
+    /// Name of the NSSound to play when dictation stops
+    @Published var dictationStopSound: String {
+        didSet {
+            UserDefaults.standard.set(dictationStopSound, forKey: Keys.dictationStopSound)
         }
     }
 
@@ -634,6 +650,10 @@ Now produce the complete meeting notes following the format above. Ensure every 
         } else {
             self.soundEffectsEnabled = true
         }
+
+        // Sound names default to Tink (start) and Pop (stop)
+        self.dictationStartSound = UserDefaults.standard.string(forKey: Keys.dictationStartSound) ?? "Tink"
+        self.dictationStopSound = UserDefaults.standard.string(forKey: Keys.dictationStopSound) ?? "Pop"
 
         // Mute while recording defaults to false (opt-in)
         if UserDefaults.standard.object(forKey: Keys.muteWhileRecording) != nil {
@@ -855,6 +875,8 @@ Now produce the complete meeting notes following the format above. Ensure every 
         skippedUpdateSHA = nil
         pauseMediaDuringDictation = true
         soundEffectsEnabled = true
+        dictationStartSound = "Tink"
+        dictationStopSound = "Pop"
         muteWhileRecording = false
         hotkeyEnabled = true
         toggleHotkeyShortcut = Hotkey(keyCode: 2, modifiers: .init(command: true, shift: true))

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -451,6 +451,42 @@ struct SettingsView: View {
                 Toggle("Play sound effects", isOn: $settings.soundEffectsEnabled)
                     .toggleStyle(.checkbox)
 
+                if settings.soundEffectsEnabled {
+                    let soundNames = ["Tink", "Pop", "Ping", "Glass", "Blow", "Bottle", "Frog", "Funk", "Hero", "Morse", "Purr", "Basso", "Sosumi", "Submarine"]
+
+                    HStack(spacing: 12) {
+                        Text("Start sound")
+                            .frame(width: 80, alignment: .leading)
+                        Picker("", selection: $settings.dictationStartSound) {
+                            ForEach(soundNames, id: \.self) { name in
+                                Text(name).tag(name)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 130)
+                        Button("▶") {
+                            NSSound(named: NSSound.Name(settings.dictationStartSound))?.play()
+                        }
+                        .buttonStyle(.borderless)
+                    }
+
+                    HStack(spacing: 12) {
+                        Text("Stop sound")
+                            .frame(width: 80, alignment: .leading)
+                        Picker("", selection: $settings.dictationStopSound) {
+                            ForEach(soundNames, id: \.self) { name in
+                                Text(name).tag(name)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 130)
+                        Button("▶") {
+                            NSSound(named: NSSound.Name(settings.dictationStopSound))?.play()
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+
                 Text("Plays a sound when dictation starts and stops")
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Sources/LookMaNoHands/Views/SettingsView.swift
+++ b/Sources/LookMaNoHands/Views/SettingsView.swift
@@ -443,6 +443,32 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
             }
 
+            // Sound Effects Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Sound Effects")
+                    .font(.headline)
+
+                Toggle("Play sound effects", isOn: $settings.soundEffectsEnabled)
+                    .toggleStyle(.checkbox)
+
+                Text("Plays a sound when dictation starts and stops")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            // Mute While Recording Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Mute While Recording")
+                    .font(.headline)
+
+                Toggle("Mute system audio while recording", isOn: $settings.muteWhileRecording)
+                    .toggleStyle(.checkbox)
+
+                Text("Silences speaker output during dictation to prevent audio bleed into the transcription")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Divider()
                 .padding(.vertical, 12)
 


### PR DESCRIPTION
## Summary

- Plays system sound cues at dictation start/stop when **Sound effects** is enabled (default on)
- **Start sound** and **Stop sound** pickers let you choose from 14 built-in macOS sounds (Tink, Pop, Ping, Glass, Blow, Bottle, Frog, Funk, Hero, Morse, Purr, Basso, Sosumi, Submarine); each picker has a ▶ preview button; pickers hide when sound effects are disabled
- Defaults: Tink (start) / Pop (stop)
- Mutes default output device via CoreAudio `kAudioDevicePropertyMute` during recording when **Mute system audio while recording** is enabled (default off); saves and restores prior mute state across all exit paths (stop, cancel/ESC, start-error); skips silently on unsupported devices
- Two new toggles + two sound pickers added to Settings → Recording tab
- Both settings persist across restarts

## Implementation notes

- Start cue plays **before** `AVAudioEngine` starts — `NSSound` is silenced once the engine takes over the audio graph
- Stop cue plays after `audioRecorder.stopRecording()` so the engine is already torn down
- Mute applied synchronously (not in the delayed media-pause `Task`) to prevent stuck-mute on sub-100ms recordings
- `kAudioDevicePropertyMute` (CoreAudio) used instead of setting virtual volume — avoids moving the volume HUD/slider
- `AudioObjectIsPropertySettable` guard + `didMute` flag ensures restore is safe on unsupported devices

## Test plan

- [ ] `swift build -c release` succeeds (no new errors)
- [ ] Settings → Recording shows Sound Effects toggle + Start/Stop sound pickers (hidden when toggle off)
- [ ] ▶ buttons play preview sounds immediately
- [ ] Dictation start → selected start sound plays; stop → selected stop sound plays
- [ ] Changing sound selection takes effect on next dictation
- [ ] Mute ON: speaker silenced during recording, restored on stop and ESC
- [ ] Both settings persist across app restarts

Closes #371